### PR TITLE
Add ix_update_error and ix_create_error so consumers can catch db exc…

### DIFF
--- a/lib/Ix/DBIC/Result.pm
+++ b/lib/Ix/DBIC/Result.pm
@@ -120,6 +120,9 @@ sub ix_create_check  { } # ($self, $ctx, \%rec)
 sub ix_update_check  { } # ($self, $ctx, $row, \%rec)
 sub ix_destroy_check { } # ($self, $ctx, $row)
 
+sub ix_create_error  { return; } # ($self, $ctx, \%error)
+sub ix_update_error  { return; } # ($self, $ctx, \%error)
+
 sub _return_ix_get   { return $_[3]->@* }
 
 sub ix_update_state_string_field { 'modSeqChanged' }

--- a/lib/Ix/DBIC/ResultSet.pm
+++ b/lib/Ix/DBIC/ResultSet.pm
@@ -375,13 +375,21 @@ sub ix_create ($self, $ctx, $to_create) {
         %default_properties{ @defaults },
       };
     } else {
-      my $error = $@;
-      unless ($error->$_DOES('Ix::Error')) {
-        $error = $ctx->error(
+      my $exception = $@;
+
+      my $error;
+
+      if (! $exception->$_DOES('Ix::Error')) {
+        $error = $rclass->ix_create_error($ctx, $exception);
+
+        $error ||= $ctx->error(
           'invalidRecord', { description => "could not create" },
-          "database rejected creation", { db_error => "$@" },
+          "database rejected creation", { db_error => "$exception" },
         );
+      } else {
+        $error = $exception;
       }
+
       $result{not_created}{$id} = $error;
     }
   }
@@ -627,10 +635,22 @@ sub ix_update ($self, $ctx, $to_update) {
       push @updated, $id;
       $result{actual_updates}++ if $ok == $UPDATED;
     } else {
-      $result{not_updated}{$id} = $ctx->error(
-        'invalidRecord', { description => "could not update" },
-        "database rejected update", { db_error => "$@" },
-      );
+      my $exception = $@;
+
+      my $error;
+
+      if (! $exception->$_DOES('Ix::Error')) {
+        $error = $rclass->ix_update_error($ctx, $exception);
+
+        $error ||= $ctx->error(
+          'invalidRecord', { description => "could not update" },
+          "database rejected update", { db_error => "$exception" },
+        );
+      } else {
+        $error = $exception;
+      }
+
+      $result{not_updated}{$id} = $error;
     }
   }
 

--- a/t/lib/Bakesale/Schema/Result/User.pm
+++ b/t/lib/Bakesale/Schema/Result/User.pm
@@ -16,6 +16,30 @@ __PACKAGE__->ix_add_properties(
 
 __PACKAGE__->set_primary_key('id');
 
+__PACKAGE__->add_unique_constraint(
+  [ qw(username) ],
+);
+
 sub ix_type_key { 'users' }
+
+sub ix_create_error ($self, $ctx, $error) {
+  if ($error =~ /duplicate key value/) {
+    return $ctx->error(alreadyExists => {
+      description => "that username already exists during create",
+    });
+  }
+
+  return;
+}
+
+sub ix_update_error ($self, $ctx, $error) {
+  if ($error =~ /duplicate key value/) {
+    return $ctx->error(alreadyExists => {
+      description => "that username already exists during update",
+    });
+  }
+
+  return;
+}
 
 1;


### PR DESCRIPTION
…eptions.

This lets things like unique key constraints and the like bubble up so that
they can be replaced by friendlier errors (instead of just being masked).
