### PR TITLE
New hook "ix_set_check_arg" runs before ix_(create|update|destroy).

### DIFF
--- a/lib/Ix/DBIC/Result.pm
+++ b/lib/Ix/DBIC/Result.pm
@@ -115,6 +115,8 @@ sub ix_finalize ($class) {
   }
 }
 
+sub ix_set_check_arg { return; } # ($self, $ctx, \%arg)
+
 sub ix_get_check     { } # ($self, $ctx, \%arg)
 sub ix_create_check  { } # ($self, $ctx, \%rec)
 sub ix_update_check  { } # ($self, $ctx, $row, \%rec)

--- a/lib/Ix/DBIC/ResultSet.pm
+++ b/lib/Ix/DBIC/ResultSet.pm
@@ -737,6 +737,11 @@ sub ix_set ($self, $ctx, $arg = {}) {
     return $ctx->error('stateMismatch');
   }
 
+  # Let consumers decide if they allow create/update/destroy or not
+  if (my $err = $rclass->ix_set_check_arg($ctx, $arg)) {
+    return $err;
+  }
+
   my %result;
 
   if ($arg->{create}) {

--- a/t/basic.t
+++ b/t/basic.t
@@ -901,4 +901,30 @@ subtest "db exceptions" => sub {
   );
 };
 
+{
+  # Make sure ix_set_check_arg works
+  my $res = $jmap_tester->request([
+    [
+      setCookies => {
+        create => {
+          actually_a_cake => { type => 'cake' },
+        },
+      }, 'first',
+    ],
+  ]);
+
+  cmp_deeply(
+    $res->as_stripped_struct->[0],
+    [
+      'error',
+      {
+        'descriptoin' => 'A cake is not a cookie',
+        'type' => 'invalidArguments'
+      },
+      'first',
+    ],
+    "Got top level error from ix_set_check_arg",
+  );
+}
+
 done_testing;

--- a/t/lib/Bakesale/Schema/Result/Cookie.pm
+++ b/t/lib/Bakesale/Schema/Result/Cookie.pm
@@ -29,6 +29,21 @@ sub ix_default_properties {
   };
 }
 
+sub ix_set_check_arg ($self, $ctx, $arg) {
+  # Tried to pass off a cake as a cookie? Throw everything out!
+  if ($arg->{create} && ref $arg->{create} eq 'HASH') {
+    for my $cookie (values $arg->{create}->%*) {
+      if ($cookie->{type} && $cookie->{type} eq 'cake') {
+        return $ctx->error(invalidArguments => {
+          descriptoin => "A cake is not a cookie",
+        });
+      }
+    }
+  }
+
+  return;
+}
+
 sub ix_update_check ($self, $ctx, $row, $arg) {
   # Can't make a half-eaten cookie into a new cookie
   if (


### PR DESCRIPTION
This lets consumers check the overall state of a method's args and
optionally throw an error for the entire method call instead of
individual entities in create/update/destroy.
