### PR TITLE
When creating a row, supplied user values may be changed.

### DIFF
--- a/lib/Ix/DBIC/Result.pm
+++ b/lib/Ix/DBIC/Result.pm
@@ -19,6 +19,10 @@ sub ix_virtual_property_names ($self, @) {
   return grep {; $prop_info->{$_}{is_virtual} } keys %$prop_info;
 }
 
+sub ix_property_names ($self, @) {
+  return keys $self->ix_property_info->%*;
+}
+
 sub ix_mutable_properties ($self, $ctx) {
   my $prop_info = $self->ix_property_info;
 

--- a/t/lib/Bakesale.pm
+++ b/t/lib/Bakesale.pm
@@ -125,7 +125,7 @@ package Bakesale {
   use namespace::autoclean;
 
   sub file_exception_report ($self, $ctx, $exception) {
-    Carp::cluck( "EXCEPTION!!" );
+    Carp::cluck( "EXCEPTION!! $exception" );
     return guid_string();
   }
 

--- a/t/lib/Bakesale/Schema/Result/User.pm
+++ b/t/lib/Bakesale/Schema/Result/User.pm
@@ -4,6 +4,8 @@ use experimental qw(postderef signatures);
 package Bakesale::Schema::Result::User;
 use base qw/DBIx::Class::Core/;
 
+use Ix::Validators qw(enum);
+
 __PACKAGE__->load_components(qw/+Ix::DBIC::Result/);
 
 __PACKAGE__->table('users');
@@ -12,6 +14,7 @@ __PACKAGE__->ix_add_columns;
 
 __PACKAGE__->ix_add_properties(
   username    => { data_type => 'text' },
+  status      => { data_type => 'text', validator => enum([ qw(active okay) ]) },
 );
 
 __PACKAGE__->set_primary_key('id');
@@ -21,6 +24,12 @@ __PACKAGE__->add_unique_constraint(
 );
 
 sub ix_type_key { 'users' }
+
+sub ix_default_properties ($self, $ctx) {
+  return {
+    status => 'active',
+  },
+}
 
 sub ix_create_error ($self, $ctx, $error) {
   if ($error =~ /duplicate key value/) {
@@ -37,6 +46,17 @@ sub ix_update_error ($self, $ctx, $error) {
     return $ctx->error(alreadyExists => {
       description => "that username already exists during update",
     });
+  }
+
+  return;
+}
+
+sub ix_create_check ($self, $ctx, $arg) {
+  # Super contrived test - change 'okay' to 'active', used to make sure
+  # behind-the-scenes changes during create bubble up to the response
+  # seen by the caller
+  if ($arg->{status} && $arg->{status} eq 'okay') {
+    $arg->{status} = 'active';
   }
 
   return;


### PR DESCRIPTION
In that case, we must be sure to return the new value as part of the
create response so clients stay in sync.
