### PR TITLE
Validate integer-like string arguments early and throw sensible errors.

### DIFF
--- a/lib/Ix/DBIC/Result.pm
+++ b/lib/Ix/DBIC/Result.pm
@@ -172,6 +172,12 @@ sub ix_compare_state ($self, $since, $state) {
   my $high_ms = $state->highest_modseq_for($self->ix_type_key);
   my $low_ms  = $state->lowest_modseq_for($self->ix_type_key);
 
+  state $bad_idstr = Ix::Validators::idstr();
+
+  if ($bad_idstr->($since)) {
+    return Ix::StateComparison->bogus;
+  }
+
   if ($high_ms  < $since) { return Ix::StateComparison->bogus;   }
   if ($low_ms  >= $since) { return Ix::StateComparison->resync;  }
   if ($high_ms == $since) { return Ix::StateComparison->in_sync; }

--- a/lib/Ix/Validators.pm
+++ b/lib/Ix/Validators.pm
@@ -5,7 +5,7 @@ package Ix::Validators;
 use experimental qw(postderef signatures);
 
 use Sub::Exporter -setup => [ qw(
-  email enum domain integer nonemptystr simplestr
+  email enum domain integer idstr nonemptystr simplestr
 ) ];
 
 sub email {
@@ -39,6 +39,15 @@ sub integer ($min = '-Inf', $max = 'Inf') {
     return "value above maximum of $max" if $x > $max;
     return;
   };
+}
+
+sub idstr ($min = -2147483648, $max = 2147483647) {
+  return sub ($x, @) {
+    return "value must be a string in the form of an integer" unless $x =~ /\A[-+]?(?:[0-9]|[1-9][0-9]*)\z/;
+    return "value below minimum of $min" if $x < $min;
+    return "value above maximum of $max" if $x > $max;
+    return;
+  }
 }
 
 sub simplestr {

--- a/t/basic.t
+++ b/t/basic.t
@@ -967,4 +967,96 @@ subtest "supplied created values changed" => sub {
   ) or diag explain $created;
 };
 
+subtest "various string id tests" => sub {
+  # id fields in JMAP are strings, but as far as Ix is concerned they
+  # are integers only. Make sure junk string ids don't throw database
+  # exceptions
+  my $res = $jmap_tester->request([
+    [ setCakes => {
+      create => {
+        "new" => { type => 'wedding', layer_count => 4, recipeId => "cat", },
+      },
+      update => {
+        "bad_id" => { type => 'wedding' },
+      },
+      destroy => [ 'to_destroy' ],
+    }, 'a', ],
+    [
+      getCakes => { ids => [ 'bad' ] }, 'b',
+    ],
+    [
+      getCookies => { sinceState => 'bad' }, 'c',
+    ],
+    [
+      getCookieUpdates => { sinceState => 'bad' }, 'd',
+    ],
+  ]);
+
+  cmp_deeply(
+    $res->as_stripped_struct,
+    [
+      [
+        'cakesSet',
+        {
+          'created' => {},
+          'destroyed' => [],
+          'newState' => ignore(),
+          'notCreated' => {
+            'new' => {
+              'description' => 'invalid property values',
+              'propertyErrors' => {
+                'recipeId' => 'value must be a string in the form of an integer'
+              },
+              'type' => 'invalidProperties'
+            }
+          },
+          'notDestroyed' => {
+            'to_destroy' => {
+              'description' => 'no such record found',
+              'type' => 'notFound'
+            }
+          },
+          'notUpdated' => {
+            'bad_id' => {
+              'description' => 'no such record found',
+              'type' => 'notFound'
+            }
+          },
+          'oldState' => ignore(),
+          'updated' => [],
+        },
+        'a',
+      ],
+      [
+        'cakes',
+        {
+          'list' => [],
+          'notFound' => [
+            'bad'
+          ],
+          'state' => ignore(),
+        },
+        'b',
+      ],
+      [
+        'error',
+        {
+          'description' => 'invalid sinceState',
+          'type' => 'invalidArguments',
+        },
+        'c'
+      ],
+      [
+        'error',
+        {
+          'description' => 'invalid sinceState',
+          'type' => 'invalidArguments',
+        },
+        'd'
+      ]
+    ],
+    "malformed id fields throw proper errors"
+  );
+};
+
 done_testing;

--- a/t/lib/Bakesale/Schema/Result/Cake.pm
+++ b/t/lib/Bakesale/Schema/Result/Cake.pm
@@ -4,7 +4,7 @@ use experimental qw(postderef signatures);
 package Bakesale::Schema::Result::Cake;
 use base qw/DBIx::Class::Core/;
 
-use Ix::Validators qw(integer nonemptystr);
+use Ix::Validators qw(integer nonemptystr idstr);
 use List::Util qw(max);
 
 __PACKAGE__->load_components(qw/+Ix::DBIC::Result/);
@@ -17,7 +17,12 @@ __PACKAGE__->ix_add_properties(
   type        => { data_type => 'text',     },
   layer_count => { data_type => 'integer',  validator => integer(1, 10)  },
   baked_at    => { data_type => 'datetime', is_immutable => 1 },
-  recipeId    => { data_type => 'integer',  xref_to => 'cakeRecipes' },
+  recipeId    => {
+    data_type    => 'string',
+    db_data_type => 'integer',
+    validator    => idstr(),
+    xref_to      => 'cakeRecipes'
+  },
 );
 
 __PACKAGE__->set_primary_key('id');


### PR DESCRIPTION
There are a number of arguments that are strings in JMAP and integers in
the database, such as id fields, and sinceState.

These weren't being validated and would throw db exceptions if non-integer
data was passed in.
