### PR TITLE
sinceState requests need getFooUpdates, not getFoos

### DIFF
--- a/lib/Ix/Context.pm
+++ b/lib/Ix/Context.pm
@@ -84,7 +84,7 @@ sub report_exception ($ctx, $exception) {
 sub error ($ctx, $type, $prop = {}, $ident = undef, $payload = undef) {
   my $report_guid;
   if (defined $ident) {
-    my $report = Ix::ExceptionReport->new({
+    my $report = Ix::ExceptionWrapper->new({
       ident => $ident,
       ($payload ? (payload => $payload) : ()),
     });
@@ -100,7 +100,7 @@ sub error ($ctx, $type, $prop = {}, $ident = undef, $payload = undef) {
 }
 
 sub internal_error ($ctx, $ident, $payload = undef) {
-  my $report = Ix::ExceptionReport->new({
+  my $report = Ix::ExceptionWrapper->new({
     ident => $ident,
     ($payload ? (payload => $payload) : ()),
   });

--- a/lib/Ix/DBIC/ResultSet.pm
+++ b/lib/Ix/DBIC/ResultSet.pm
@@ -34,7 +34,6 @@ sub ix_get ($self, $ctx, $arg = {}) {
     if $rclass->can('ix_preprocess_get_arg');
 
   my $ids   = $arg->{ids};
-  my $since = $arg->{sinceState};
 
   my $prop_info = $rclass->ix_property_info;
   my %is_prop   = map  {; $_ => 1 }
@@ -72,7 +71,6 @@ sub ix_get ($self, $ctx, $arg = {}) {
   my @rows = $self->search(
     {
       datasetId => $datasetId,
-      (defined $since ? (modSeqChanged => { '>' => $since }) : ()),
       ($ids ? (id => \@ids) : ()),
       dateDeleted => undef,
       %$x_get_cond,

--- a/lib/Ix/Error.pm
+++ b/lib/Ix/Error.pm
@@ -13,7 +13,7 @@ sub result_type { 'error' }
 requires 'error_type';
 
 package
-  Ix::ExceptionReport {
+  Ix::ExceptionWrapper {
 
   use Moose;
   use namespace::autoclean;

--- a/t/basic.t
+++ b/t/basic.t
@@ -71,11 +71,16 @@ $jmap_tester->_set_cookie('bakesaleUserId', $dataset{users}{rjbs});
 
 {
   my $res = $jmap_tester->request([
-    [ getCookies => { sinceState => 2, properties => [ qw(type) ] } ],
+    [ getCookieUpdates => {
+        sinceState   => 2,
+        fetchRecords => \1,
+        fetchRecordProperties => [ qw(type) ],
+      }
+    ],
   ]);
 
   isa_ok(
-    $res->as_struct->[0][1]{list}[0]{id},
+    $res->as_struct->[1][1]{list}[0]{id},
     'JSON::Typist::String',
     "the returned id",
   ) or diag(explain($res->as_struct));
@@ -83,6 +88,7 @@ $jmap_tester->_set_cookie('bakesaleUserId', $dataset{users}{rjbs});
   cmp_deeply(
     $jmap_tester->strip_json_types( $res->as_pairs ),
     [
+      [ cookieUpdates => ignore() ],
       [
         cookies => {
           notFound => undef,
@@ -737,7 +743,13 @@ subtest "datetime field validations" => sub {
 
   # Verify
   $res = $jmap_tester->request([
-    [ getCookies => { sinceState => $state - 1, properties => [ qw(type baked_at expires_at) ] } ],
+    [
+      getCookieUpdates => {
+        sinceState => $state - 1,
+        fetchRecords => \1,
+        fetchRecordProperties => [ qw(type baked_at expires_at) ],
+      },
+    ],
   ]);
 
   my $data = $jmap_tester->strip_json_types($res->as_pairs);
@@ -745,6 +757,7 @@ subtest "datetime field validations" => sub {
   cmp_deeply(
     $data,
     [
+      [ cookieUpdates => ignore() ],
       [
         cookies => {
           notFound => undef,
@@ -765,7 +778,7 @@ subtest "datetime field validations" => sub {
 
   my %c_to_id = map {;
     $_->{type} => $_->{id}
-  } @{ $data->[0][1]{list} };
+  } @{ $data->[1][1]{list} };
 
   $res = $jmap_tester->request([
     [
@@ -815,7 +828,13 @@ subtest "datetime field validations" => sub {
 
   # Verify (still using much older state so we can see white in the list)
   $res = $jmap_tester->request([
-    [ getCookies => { sinceState => $state - 2, properties => [ qw(type baked_at expires_at) ] } ],
+    [
+      getCookieUpdates => {
+        sinceState => $state - 2,
+        fetchRecords => \1,
+        fetchRecordProperties => [ qw(type baked_at expires_at) ],
+      },
+    ],
   ]);
 
   $data = $jmap_tester->strip_json_types($res->as_pairs);
@@ -823,6 +842,7 @@ subtest "datetime field validations" => sub {
   cmp_deeply(
     $data,
     [
+      [ cookieUpdates => ignore() ],
       [
         cookies => {
           notFound => undef,

--- a/t/processor/basic.t
+++ b/t/processor/basic.t
@@ -54,12 +54,20 @@ my $ctx = $Bakesale->get_context({
 
 {
   my $res = $ctx->process_request([
-    [ getCookies => { sinceState => 2, properties => [ qw(type) ] }, 'a' ],
+    [
+      getCookieUpdates => {
+        sinceState => 2,
+        fetchRecords => \1,
+        fetchRecordProperties => [ qw(type) ]
+      },
+      'a',
+    ],
   ]);
 
-  is_deeply(
+  cmp_deeply(
     $res,
     [
+      [ cookieUpdates => ignore(), 'a' ],
       [
         cookies => {
           notFound => undef,
@@ -397,12 +405,19 @@ subtest "invalid sinceState" => sub {
 
   # Verify we got the right dates
   $res = $ctx->process_request([
-    [ getCookies => { sinceState => 9, properties => [ qw(type baked_at) ] }, 'a' ],
+    [
+      getCookieUpdates => {
+        sinceState => 9,
+        fetchRecords => \1,
+        fetchRecordProperties => [ qw(type baked_at) ]
+      }, 'a',
+    ],
   ]);
 
   cmp_deeply(
     $res,
     [
+      [ cookieUpdates => ignore(), 'a' ],
       [
         cookies => {
           notFound => undef,
@@ -418,11 +433,11 @@ subtest "invalid sinceState" => sub {
     "a getFoos call backed by the database",
   ) or diag explain($res);
 
-  ok($res->[0][1]{list}[0]{baked_at}->$_isa('DateTime'), 'got a dt object');
-  is($res->[0][1]{list}[0]{baked_at}->as_string, $past_str, 'time is right');
+  ok($res->[1][1]{list}[0]{baked_at}->$_isa('DateTime'), 'got a dt object');
+  is($res->[1][1]{list}[0]{baked_at}->as_string, $past_str, 'time is right');
 
-  ok($res->[0][1]{list}[1]{baked_at}->$_isa('DateTime'), 'got a dt object');
-  is($res->[0][1]{list}[1]{baked_at}->as_string, $past_str, 'time is right');
+  ok($res->[1][1]{list}[1]{baked_at}->$_isa('DateTime'), 'got a dt object');
+  is($res->[1][1]{list}[1]{baked_at}->as_string, $past_str, 'time is right');
 
   $past->add(days => 10);
   $ixdt->add(days => 10);
@@ -464,12 +479,19 @@ subtest "invalid sinceState" => sub {
 
   # Verify we updated to the new past
   $res = $ctx->process_request([
-    [ getCookies => { sinceState => 10, properties => [ qw(type baked_at) ] }, 'a' ],
+    [
+      getCookieUpdates => {
+        sinceState => 10,
+        fetchRecords => \1,
+        fetchRecordProperties => [ qw(type baked_at) ]
+      }, 'a',
+    ],
   ]);
 
   cmp_deeply(
     $res,
     [
+      [ cookieUpdates => ignore(), 'a' ],
       [
         cookies => {
           notFound => undef,
@@ -484,8 +506,8 @@ subtest "invalid sinceState" => sub {
     "a getFoos call backed by the database",
   ) or diag explain($res);
 
-  ok($res->[0][1]{list}[0]{baked_at}->$_isa('DateTime'), 'got a dt object');
-  is($res->[0][1]{list}[0]{baked_at}->as_string, $past_str, 'time is right');
+  ok($res->[1][1]{list}[0]{baked_at}->$_isa('DateTime'), 'got a dt object');
+  is($res->[1][1]{list}[0]{baked_at}->as_string, $past_str, 'time is right');
 }
 
 {


### PR DESCRIPTION
caught by @wolfsage 

Silly mistake dating from the first few commits to Ix.
