### PR TITLE
Add destroy hook ix_destroy_munge_properties.

### DIFF
--- a/lib/Ix/DBIC/ResultSet.pm
+++ b/lib/Ix/DBIC/ResultSet.pm
@@ -745,9 +745,17 @@ sub ix_destroy ($self, $ctx, $to_destroy) {
       next DESTROY;
     }
 
+    my $munged = {};
+
+    if ($rclass->can('ix_destroy_munge_properties')) {
+      $munged = $rclass->ix_destroy_munge_properties($ctx, $row);
+    }
+
     my $ok = eval {
       $ctx->schema->txn_do(sub {
         $row->update({
+          %$munged,
+
           modSeqChanged => $next_state,
           dateDeleted   => Ix::DateTime->now,
         });

--- a/t/basic.t
+++ b/t/basic.t
@@ -1171,4 +1171,48 @@ subtest "virtual properties in create" => sub {
   );
 };
 
+subtest "delete munging" => sub {
+  # Make sure destroying an object munges any data fields that subclasses
+  # requested. This is necessary so that deleted data doesn't get in the
+  # way of unique constraints
+
+  my $res = $jmap_tester->request([
+    [ setUsers => {
+      create => {
+        first => { username => 'a new user', },
+      },
+    } ],
+  ]);
+
+  my $id = $res->paragraph(0)->single('usersSet')->as_set->created_id('first');
+  ok($id, 'created a user');
+
+  # Destroy that user
+  $res = $jmap_tester->request([
+     [ setUsers => {
+       destroy => [ $id ],
+     } ],
+  ]);
+  is(
+    ($res->single_sentence('usersSet')->as_set->destroyed_ids)[0],
+    $id,
+    'user destroyed'
+  );
+
+  # Now create a new user with same username
+  $res = $jmap_tester->request([
+    [ setUsers => {
+      create => {
+        first => { username => 'a new user', },
+      },
+    } ],
+  ]);
+
+  my $id2 = $res->paragraph(0)->single('usersSet')->as_set->created_id('first');
+  ok($id2, 'created a user with same username as destroyed user')
+    or diag explain $res->as_stripped_struct;
+
+  cmp_ok($id2, '!=', $id, "new user has a different id");
+};
+
 done_testing;

--- a/t/lib/Bakesale/Schema/Result/User.pm
+++ b/t/lib/Bakesale/Schema/Result/User.pm
@@ -94,4 +94,11 @@ sub ix_postprocess_create ($self, $ctx, $rows) {
   return;
 }
 
+sub ix_destroy_munge_properties ($self, $ctx, $row) {
+  # Pretend this isn't valid so no user could be created like this
+  return {
+    username => ";DELETED;" . $row->username,
+  };
+}
+
 1;


### PR DESCRIPTION
This lets subclasses muck with data on delete so that deleted data doesn't
interfere with live data (for things like unique constraints).
