### PR TITLE
Add ix_add_unique_constraint(s) so destroyed rows don't block active …

### DIFF
--- a/lib/Ix/DBIC/ResultSet.pm
+++ b/lib/Ix/DBIC/ResultSet.pm
@@ -750,6 +750,10 @@ sub ix_destroy ($self, $ctx, $to_destroy) {
         $row->update({
           modSeqChanged => $next_state,
           dateDeleted   => Ix::DateTime->now,
+
+          # Null this out making any unique constraints unblocked for
+          # a new create (since null is never == null in postgres)
+          isActive      => undef,
         });
         return 1;
       });

--- a/t/lib/Bakesale/Schema/Result/User.pm
+++ b/t/lib/Bakesale/Schema/Result/User.pm
@@ -20,7 +20,7 @@ __PACKAGE__->ix_add_properties(
 
 __PACKAGE__->set_primary_key('id');
 
-__PACKAGE__->add_unique_constraint(
+__PACKAGE__->ix_add_unique_constraint(
   [ qw(username) ],
 );
 


### PR DESCRIPTION
…ones.

We never delete rows, so we need a way for unique constraints to only be
applied when the row is active.
