### PR TITLE
new_test_app_and_tester now creates/deploys only *1* database per use.

### DIFF
--- a/t/lib/Bakesale.pm
+++ b/t/lib/Bakesale.pm
@@ -9,11 +9,7 @@ package Bakesale::Test {
     require JMAP::Tester;
     require LWP::Protocol::PSGI;
 
-    my ($user_id, $conn_info) = Bakesale::Test->test_schema_connect_info;
-
-    my $app = Bakesale::App->new({
-      connect_info => $conn_info,
-    });
+    my $app = Bakesale::App->new;
 
     state $n;
     $n++;
@@ -22,7 +18,7 @@ package Bakesale::Test {
       jmap_uri => "http://bakesale.local:$n/jmap",
     });
 
-    return ($app, $jmap_tester, $user_id);
+    return ($app, $jmap_tester);
   }
 
   my @TEST_DBS;


### PR DESCRIPTION
- test_schema_connect_info returns a single arrayref of the db connection
  info, it does not create and return any user id.
- Bakesale::App->new doesn't take a connect_info arg, so the created db
  was being discarded. Bakesale lazily calls test_schema_connect_info when
  connect_info is first accessed.
