### PR TITLE
Allow syncing from the base state of 0.

### DIFF
--- a/lib/Ix/DBIC/Result.pm
+++ b/lib/Ix/DBIC/Result.pm
@@ -213,7 +213,7 @@ sub ix_compare_state ($self, $since, $state) {
   }
 
   if ($high_ms  < $since) { return Ix::StateComparison->bogus;   }
-  if ($low_ms  >= $since) { return Ix::StateComparison->resync;  }
+  if ($low_ms   > $since) { return Ix::StateComparison->resync;  }
   if ($high_ms == $since) { return Ix::StateComparison->in_sync; }
 
   return Ix::StateComparison->okay;

--- a/lib/Ix/DBIC/ResultSet.pm
+++ b/lib/Ix/DBIC/ResultSet.pm
@@ -158,7 +158,7 @@ sub ix_get_updates ($self, $ctx, $arg = {}) {
 
   if ($statecmp->is_resync) {
     $ctx->error(cannotCalculateChanges => {
-      description => "client cache must be reconstucted"
+      description => "client cache must be reconstructed"
     })->throw
   }
 

--- a/t/lib/Bakesale.pm
+++ b/t/lib/Bakesale.pm
@@ -48,7 +48,9 @@ package Bakesale::Test {
       modSeqChanged => 1,
     });
 
-    return $user1->id;
+    $user1 = $user_rs->single({ id => $user1->id });
+
+    return ($user1->id, $user1->datasetId);
   }
 
   sub load_trivial_dataset ($self, $schema) {
@@ -71,6 +73,14 @@ package Bakesale::Test {
     });
 
     $user2 = $user_rs->single({ id => $user2->id });
+
+    my $user3 = $user_rs->create({
+      datasetId => \q{pseudo_encrypt(nextval('key_seed_seq')::int)},
+      username  => 'alh',
+      modseq(1)
+    });
+
+    $user3 = $user_rs->single({ id => $user3->id });
 
     my $a1 = $user1->datasetId;
     my $a2 = $user2->datasetId;
@@ -102,8 +112,8 @@ package Bakesale::Test {
     ]);
 
     return {
-      datasets => { rjbs => $a1, neilj => $a2 },
-      users    => { rjbs => $user1->id, neilj => $user2->id },
+      datasets => { rjbs => $a1, neilj => $a2, alh => $user3->datasetId, },
+      users    => { rjbs => $user1->id, neilj => $user2->id, alh => $user3->id, },
       recipes  => { 1 => $recipes[0]->id },
       cookies  => { map {; ($_+1) => $cookies[$_]->id } keys @cookies },
     };

--- a/t/lib/Bakesale/Schema/Result/Cake.pm
+++ b/t/lib/Bakesale/Schema/Result/Cake.pm
@@ -64,7 +64,7 @@ sub ix_compare_state ($self, $since, $state) {
     return Ix::StateComparison->bogus;
   }
 
-  if ($cake_low >= $cake_since || $recipe_low >= $recipe_since) {
+  if ($cake_low > $cake_since || $recipe_low > $recipe_since) {
     return Ix::StateComparison->resync;
   }
 

--- a/t/processor/basic.t
+++ b/t/processor/basic.t
@@ -231,7 +231,7 @@ subtest "invalid sinceState" => sub {
 
   subtest "too low" => sub {
     my $res = $ctx->process_request([
-      [ getCookieUpdates => { sinceState => 1 }, 'a' ],
+      [ getCookieUpdates => { sinceState => 0 }, 'a' ],
     ]);
 
     cmp_deeply(


### PR DESCRIPTION
0 is the state you get when no entities have been created for a specific class
yet. If you then add an entity, the state will be '1'. getFooUpdates with a
sinceState of 0 should be able to calculate the changes for you.

0-0 is also valid for complex states.
