### PR TITLE
Filter out rows created and deleted after requested state in Get*Updates

### DIFF
--- a/lib/Ix/DBIC/Result.pm
+++ b/lib/Ix/DBIC/Result.pm
@@ -191,6 +191,13 @@ sub ix_update_extra_search ($self, $ctx, $arg) {
   return (
     {
       'me.modSeqChanged' => { '>' => $since },
+
+      # Don't include rows that were created and deleted after
+      # our current state
+      -or => [
+        'me.dateDeleted' => undef,
+        'me.modSeqCreated' => { '<=' => $since },
+      ],
     },
     {},
   );


### PR DESCRIPTION
If we're at state 1, and a cookie is created at state 2 and then destroyed at
state 3, requesting updates from state 1 should return an empty list since
there are no active rows to return changes for.
