### PR TITLE
mark integer properties as is_numeric in ResultSource

### DIFF
--- a/lib/Ix/DBIC/Result.pm
+++ b/lib/Ix/DBIC/Result.pm
@@ -86,7 +86,7 @@ my %IX_TYPE = (
   datetime => { data_type => 'timestamptz' },
 
   boolean  => { data_type => 'boolean' },
-  integer  => { data_type => 'integer' },
+  integer  => { data_type => 'integer', is_numeric => 1 },
 );
 
 sub ix_add_properties ($class, @pairs) {


### PR DESCRIPTION
This commit is two parts: let the Ix property type imply more, and specifically make integer imply `is_numeric => 1`.
