### PR TITLE
Unify access logging and transaction logging.

### DIFF
--- a/t/lib/Bakesale.pm
+++ b/t/lib/Bakesale.pm
@@ -10,7 +10,7 @@ package Bakesale::Test {
     require LWP::Protocol::PSGI;
 
     my $app = Bakesale::App->new({
-      log_all_transactions => 1,
+      transaction_log_enabled => 1,
     });
 
     state $n;

--- a/t/lib/Bakesale/App.pm
+++ b/t/lib/Bakesale/App.pm
@@ -14,9 +14,9 @@ has transaction_log => (
   default  => sub {  []  },
   traits   => [ 'Array' ],
   handles  => {
-    log_transaction       => 'push',
     clear_transaction_log => 'clear',
     logged_transactions   => 'elements',
+    emit_transaction_log  => 'push',
   },
 );
 


### PR DESCRIPTION
Both can be enabled by setting "$type_log_enabled" to true, and the log
methods are "log_$type" instead of "log_$type_log".

You can override "build_$type_log_entry" to build the hashref representing
the log entry.

You can overrride "emit_$type_log" which will be called to actually send
the log entry _somewhere_.
