### PR TITLE
Allow masking props of request/response structures when logging

### DIFF
--- a/lib/Ix/App/JMAP.pm
+++ b/lib/Ix/App/JMAP.pm
@@ -33,6 +33,7 @@ sub _core_request ($self, $ctx, $req) {
 
   $req->env->{'ix.transaction'}{jmap}{calls} = $calls;
   my $result  = $ctx->process_request( $calls );
+  $req->env->{'ix.transaction'}{jmap}{result} = $result;
   my $json    = $self->encode_json($result);
 
   return [

--- a/lib/Ix/Result/Masked.pm
+++ b/lib/Ix/Result/Masked.pm
@@ -1,0 +1,28 @@
+use 5.20.0;
+
+package Ix::Result::Masked;
+use Moose;
+
+use experimental qw(signatures postderef);
+
+use overload fallback => 1, '""' => \&maybe_mask_value;
+
+our $MASKING = 0;
+
+sub on { $MASKING = 1; }
+sub off { $MASKING = 0; }
+
+has value => (
+  is => 'ro',
+);
+
+sub maybe_mask_value ($self, @) {
+  return $MASKING ? '***MASKED***' : $self->value;
+}
+
+sub TO_JSON ($self, @) {
+  return "$self";
+}
+
+1;
+

--- a/lib/Ix/Util.pm
+++ b/lib/Ix/Util.pm
@@ -5,10 +5,28 @@ use experimental qw(signatures postderef);
 
 use DateTime::Format::Pg;
 use DateTime::Format::RFC3339;
-use Sub::Exporter -setup => [ qw(parsedate parsepgdate) ];
+use Sub::Exporter -setup => [ qw(parsedate parsepgdate mask_results mask_value) ];
+use Ix::Result::Masked;
+use Try::Tiny;
 
 my $pg = DateTime::Format::Pg->new();
 my $rfc3339 = DateTime::Format::RFC3339->new();
+
+sub mask_results ($block) :prototype(&) {
+  try {
+    Ix::Result::Masked->on;
+
+    $block->();
+  } catch {
+    die $_; # rethrow
+  } finally {
+    Ix::Result::Masked->off;
+  }
+}
+
+sub mask_value ($value = undef) {
+  return Ix::Result::Masked->new({ value => $value });
+}
 
 sub parsepgdate ($str) {
   my $dt;

--- a/t/lib/Bakesale/Schema/Result/Cake.pm
+++ b/t/lib/Bakesale/Schema/Result/Cake.pm
@@ -17,6 +17,7 @@ __PACKAGE__->ix_add_properties(
   type        => { data_type => 'string',     },
   layer_count => { data_type => 'integer',  validator => integer(1, 10)  },
   baked_at    => { data_type => 'datetime', is_immutable => 1 },
+  phrase      => { data_type => 'string', is_optional => 1, masked => 1 },
   recipeId    => {
     data_type    => 'string',
     db_data_type => 'integer',

--- a/t/transaction_log.t
+++ b/t/transaction_log.t
@@ -1,0 +1,120 @@
+use 5.20.0;
+use warnings;
+use utf8;
+use experimental qw(lexical_subs signatures postderef refaliasing);
+
+use lib 't/lib';
+
+use Bakesale;
+use Bakesale::App;
+use Bakesale::Schema;
+use JSON;
+use Test::Deep;
+use Test::Deep::JType;
+use Test::More;
+use Unicode::Normalize;
+
+my ($app, $jmap_tester) = Bakesale::Test->new_test_app_and_tester;
+\my %account = Bakesale::Test->load_trivial_account($app->processor->schema_connection);
+
+$jmap_tester->_set_cookie('bakesaleUserId', $account{users}{rjbs});
+
+{
+  $app->clear_transaction_log;
+
+  # setCakes/create setCakes/update getCakes can mask secret fields
+  my $res = $jmap_tester->request([
+    [
+      setCakes => {
+        create    => {
+          yum => { type => 'layered', phrase => "happy birthday", layer_count => 4, recipeId => $account{recipes}{1} },
+        }
+      },
+    ]
+  ]);
+
+  my $id = $res->single_sentence->as_set->created_id('yum');
+  ok($id, 'created a cake');
+
+  jcmp_deeply(
+    $res->single_sentence->as_set->arguments->{created},
+    {
+      yum => {
+        baked_at => ignore(),
+        id       => ignore()
+      },
+    },
+    'created structure looks right'
+  );
+
+  # Verify
+  $res = $jmap_tester->request([
+    [
+      getCakes => {
+        ids => [ $id ],
+      },
+    ],
+  ]);
+
+  is(
+    $res->single_sentence->arguments->{list}[0]{phrase},
+    'happy birthday',
+    'phrase is correct'
+  );
+
+  $res = $jmap_tester->request([
+    [
+      setCakes => {
+        update => {
+          $id => { phrase => "happy birthday you" },
+        },
+      },
+    ]
+  ]);
+
+  cmp_deeply(
+    [ $res->single_sentence->as_set->updated_ids ],
+    [ $id ],
+    'item updated'
+  );
+
+  # verify 
+  $res = $jmap_tester->request([
+    [
+      getCakes => {
+        ids => [ $id ],
+      },
+    ],
+  ]);
+
+  is(
+    $res->single_sentence->arguments->{list}[0]{phrase},
+    'happy birthday you',
+    'phrase is correct'
+  );
+
+  my @xacts = $app->drain_transaction_log;
+  is(@xacts, 4, "we log transactions (at least when testing)");
+
+  for my $log (@xacts) {
+    my $req = $log->{request};
+    ok($req, 'got a logged request');
+
+    if ($req =~ /setCakes/) {
+      like($req, qr/\Q"phrase":"***MASKED***"\E/, 'got a masked req');
+    } else {
+      unlike($req, qr/\Qphrase\E/, 'getCakes request has no phrase');
+    }
+
+    my $res = $log->{response};
+    ok($res, 'got a logged response');
+
+    if ($req =~ /setCakes/) {
+      unlike($res, qr/\Qphrase\E/, 'setCakes response has no phrase');
+    } else {
+      like($res, qr/\Q"phrase":"***MASKED***"\E/, 'got a masked response');
+    }
+  }
+}
+
+done_testing;


### PR DESCRIPTION
Add new ix property 'masked' which will cause those values to be
replaced with '***MASKED***' in the transacton logs for both the
requests and the response

For non-ix properties, mask_value() can be used to mask whatever
needs masking