### PR TITLE
Standardize on 'timestamptz' for date / time fields

### DIFF
--- a/lib/Ix/DBIC/Result.pm
+++ b/lib/Ix/DBIC/Result.pm
@@ -56,7 +56,7 @@ sub ix_add_columns ($class) {
     accountId     => { data_type => 'integer' },
     modSeqCreated => { data_type => 'integer' },
     modSeqChanged => { data_type => 'integer' },
-    dateDeleted   => { data_type => 'datetime', is_nullable => 1 },
+    dateDeleted   => { data_type => 'timestamptz', is_nullable => 1 },
     isActive      => { data_type => 'boolean', is_nullable => 1, default_value => 1 },
   );
 }
@@ -85,11 +85,11 @@ sub ix_add_unique_constraint ($class, @constraint) {
 
 my %IX_TYPE = (
   # idstr should get done this way in the future
-  string   => { data_type => 'text' },
-  datetime => { data_type => 'timestamptz' },
+  string       => { data_type => 'text' },
+  timestamptz  => { data_type => 'timestamptz' },
 
-  boolean  => { data_type => 'boolean' },
-  integer  => { data_type => 'integer', is_numeric => 1 },
+  boolean      => { data_type => 'boolean' },
+  integer      => { data_type => 'integer', is_numeric => 1 },
 );
 
 sub ix_add_properties ($class, @pairs) {

--- a/lib/Ix/DBIC/ResultSet.pm
+++ b/lib/Ix/DBIC/ResultSet.pm
@@ -456,7 +456,7 @@ sub _ix_check_user_properties (
   my %property_error;
 
   my %date_fields = map {; $_ => 1 }
-                    grep {; ($prop_info->{$_}{data_type} // '') eq 'datetime' }
+                    grep {; ($prop_info->{$_}{data_type} // '') eq 'timestamptz' }
                     keys %$prop_info;
 
   # Dedupe
@@ -618,7 +618,7 @@ sub _ix_wash_rows ($self, $rows) {
       $row->{$key} = $row->{$key} ? $true : $false if defined $row->{$key};
     }
 
-    for my $key ($by_type{datetime}->@*) {
+    for my $key ($by_type{timestamptz}->@*) {
       if ($row->{$key}) {
         # Doesn't already look like an RFC3339 Zulu date?
         if ($row->{$key} !~ /Z/) {

--- a/t/lib/Bakesale/Schema/Result/Cake.pm
+++ b/t/lib/Bakesale/Schema/Result/Cake.pm
@@ -16,7 +16,7 @@ __PACKAGE__->ix_add_columns;
 __PACKAGE__->ix_add_properties(
   type        => { data_type => 'string',     },
   layer_count => { data_type => 'integer',  validator => integer(1, 10)  },
-  baked_at    => { data_type => 'datetime', is_immutable => 1 },
+  baked_at    => { data_type => 'timestamptz', is_immutable => 1 },
   recipeId    => {
     data_type    => 'string',
     db_data_type => 'integer',

--- a/t/lib/Bakesale/Schema/Result/Cookie.pm
+++ b/t/lib/Bakesale/Schema/Result/Cookie.pm
@@ -13,8 +13,8 @@ __PACKAGE__->ix_add_columns;
 
 __PACKAGE__->ix_add_properties(
   type       => { data_type => 'string', },
-  baked_at   => { data_type => 'datetime', is_optional => 1 },
-  expires_at => { data_type => 'datetime', is_optional => 0 },
+  baked_at   => { data_type => 'timestamptz', is_optional => 1 },
+  expires_at => { data_type => 'timestamptz', is_optional => 0 },
   delicious  => { data_type => 'string', is_optional => 0 },
 );
 


### PR DESCRIPTION
We want to store times with timezone information. This is useful incase
something writes data to the DB in other timezones than UTC - when retrieved,
the data will still be correct.

Require Ix users to specify 'timestamptz' instead of 'datetime' since
SQL::Translator takes 'datetime' to mean 'timestamp without timezone'.