### PR TITLE
Add 'behind_proxy' setting to conditionally load ReverseProxy middleware

### DIFF
--- a/lib/Ix/Processor.pm
+++ b/lib/Ix/Processor.pm
@@ -18,6 +18,12 @@ requires 'connect_info';
 
 requires 'context_from_plack_request';
 
+has behind_proxy => (
+  is  => 'rw',
+  isa => 'Bool',
+  default => 0,
+);
+
 sub schema_connection ($self) {
   $self->schema_class->connect(
     $self->connect_info,


### PR DESCRIPTION
This way $req->remote_addr and $req->remote_host will be correct if running
behind, say, nginx.