### PR TITLE
use MooseX::StrictConstructor on Moose classes

### DIFF
--- a/lib/Ix/AccountState.pm
+++ b/lib/Ix/AccountState.pm
@@ -3,7 +3,7 @@ use warnings;
 package Ix::AccountState;
 
 use Moose;
-
+use MooseX::StrictConstructor;
 use experimental qw(signatures postderef);
 
 use namespace::clean;

--- a/lib/Ix/Error.pm
+++ b/lib/Ix/Error.pm
@@ -16,6 +16,7 @@ package
   Ix::ExceptionWrapper {
 
   use Moose;
+  use MooseX::StrictConstructor;
   use namespace::autoclean;
 
   with 'StackTrace::Auto';
@@ -36,7 +37,7 @@ package
 package Ix::Error::Internal {
 
   use Moose;
-
+  use MooseX::StrictConstructor;
   use experimental qw(signatures postderef);
 
   use namespace::autoclean;
@@ -75,7 +76,7 @@ package Ix::Error::Internal {
 package Ix::Error::Generic {
 
   use Moose;
-
+  use MooseX::StrictConstructor;
   use experimental qw(signatures postderef);
 
   use namespace::autoclean;

--- a/lib/Ix/Result.pm
+++ b/lib/Ix/Result.pm
@@ -12,6 +12,7 @@ requires 'result_arguments';
 package Ix::Result::Generic {
 
   use Moose;
+  use MooseX::StrictConstructor;
   use experimental qw(signatures postderef);
 
   use namespace::autoclean;
@@ -29,6 +30,7 @@ package Ix::Result::Generic {
 package Ix::Result::FoosSet {
 
   use Moose;
+  use MooseX::StrictConstructor;
   use experimental qw(signatures postderef);
 
   use namespace::autoclean;


### PR DESCRIPTION
This will catch bogus arguments to new.