### PR TITLE
ix_update: when the server sets properties, tell the client

### DIFF
--- a/t/lib/Bakesale/Schema/Result/Cookie.pm
+++ b/t/lib/Bakesale/Schema/Result/Cookie.pm
@@ -59,21 +59,23 @@ sub ix_create_check ($self, $ctx, $arg) {
   return;
 }
 
-sub ix_update_check ($self, $ctx, $row, $arg) {
+sub ix_update_check ($self, $ctx, $row, $rec) {
   # Can't make a half-eaten cookie into a new cookie
   if (
-       $arg->{type}
-    && $arg->{type} !~ /eaten/i
+       $rec->{type}
+    && $rec->{type} !~ /eaten/i
     && $row->type =~ /eaten/i
   ) {
     return $ctx->error(partyFoul => {
       description => "You can't pretend you haven't eaten a part of that coookie!",
     });
-
-    return;
   }
 
-  if (my $err = $self->_check_baked_at($ctx, $arg)) {
+  if ($rec->{type} && $rec->{type} eq 'macaron') {
+    $rec->{delicious} = 'eh';
+  }
+
+  if (my $err = $self->_check_baked_at($ctx, $rec)) {
     return $err;
   }
 


### PR DESCRIPTION
Worth noting is that this will not yet report cases when the server
sets a propert the user tried to update, but sets a different value.
We want a better Ix::Util::differ before we implement that.

This should meet all our need for now, though.