### PR TITLE
Don't return duplicate rows in get_foo_list/get_foo_list_updates

### DIFF
--- a/lib/Ix/DBIC/ResultSet.pm
+++ b/lib/Ix/DBIC/ResultSet.pm
@@ -978,6 +978,7 @@ sub ix_get_list ($self, $ctx, $arg = {}) {
     {
       $search->{sort}->%*,
       $search->{join}->%*,
+      distinct => 1,
     },
   )->count;
 
@@ -989,6 +990,7 @@ sub ix_get_list ($self, $ctx, $arg = {}) {
       rows      => $limit,
       offset    => $arg->{position} // 0,
       result_class => 'DBIx::Class::ResultClass::HashRefInflator',
+      distinct => 1,
     },
   );
 
@@ -1083,6 +1085,7 @@ sub ix_get_list_updates ($self, $ctx, $arg = {}) {
     {
       $search->{sort}->%*,
       $search->{join}->%*,
+      distinct => 1,
     },
   )->search({ 'me.isActive' => 1 })->count;
 
@@ -1130,6 +1133,7 @@ sub ix_get_list_updates ($self, $ctx, $arg = {}) {
     {
       $search->{sort}->%*,
       $search->{join}->%*,
+      distinct => 1,
     },
   )->all;
 

--- a/t/access_log.t
+++ b/t/access_log.t
@@ -55,12 +55,12 @@ $jmap_tester->_set_cookie('bakesaleUserId', $account{users}{rjbs});
             {
               cakeId => $res->as_stripped_struct->[0][1]{created}{yum}{id},
               id => ignore(),
-              type => 'basic'
+              type => 'wedding'
             },
             {
               cakeId => $res->as_stripped_struct->[0][1]{created}{woo}{id},
               id => ignore(),
-              type => 'basic'
+              type => 'wedding'
             },
           ),
           notFound => ignore(),

--- a/t/basic.t
+++ b/t/basic.t
@@ -1441,12 +1441,12 @@ subtest "ix_created test" => sub {
             {
               cakeId => $res->as_stripped_struct->[0][1]{created}{yum}{id},
               id => ignore(),
-              type => 'basic'
+              type => 'wedding'
             },
             {
               cakeId => $res->as_stripped_struct->[0][1]{created}{woo}{id},
               id => ignore(),
-              type => 'basic'
+              type => 'wedding'
             },
           ),
           notFound => ignore(),

--- a/t/lib/Bakesale/Schema/Result/CakeTopper.pm
+++ b/t/lib/Bakesale/Schema/Result/CakeTopper.pm
@@ -28,7 +28,7 @@ sub ix_type_key { 'cakeToppers' }
 sub ix_account_type { 'generic' }
 
 sub ix_default_properties {
-  return { type => 'basic' };
+  return { type => 'wedding' };
 }
 
 __PACKAGE__->belongs_to(


### PR DESCRIPTION
LEFT JOINS in certain situations can cause our searches to return
duplicate rows.

Use DBIC's 'distinct' feature to prevent that (it internally
does a GROUP BY on all of the main table's columns).