### PR TITLE
Don't use ->find(), its behaviour is awful and throws away params

### DIFF
--- a/lib/Ix/DBIC/ResultSet.pm
+++ b/lib/Ix/DBIC/ResultSet.pm
@@ -684,9 +684,9 @@ sub ix_update ($self, $ctx, $to_update) {
     my $row;
 
     unless ($bad_idstr->($id)) {
-      $row = $self->find({
-        id => $id,
-        accountId   => $accountId,
+      $row = $self->single({
+        id            => $id,
+        accountId     => $accountId,
         dateDestroyed => undef,
       });
     }
@@ -817,11 +817,11 @@ sub ix_destroy ($self, $ctx, $to_destroy) {
     my $row;
 
     unless ($bad_idstr->($id)) {
-      $row = $self->search({
-        id => $id,
-        accountId => $accountId,
+      $row = $self->single({
+        id            => $id,
+        accountId     => $accountId,
         dateDestroyed => undef,
-      })->first;
+      });
     }
 
     unless ($row) {

--- a/t/basic.t
+++ b/t/basic.t
@@ -1880,4 +1880,51 @@ subtest "friendly duplicate key errors" => sub {
   );
 };
 
+subtest "cannot update a destroyed row" => sub {
+  my $create_res = $jmap_tester->request([
+    [ setUsers => {
+      create => {
+        first  => { username => 'auser', },
+      },
+    } ],
+  ]);
+
+  ok(
+    my $first_id = $create_res->single_sentence->as_set->created_id('first'),
+    'created first user'
+  );
+
+  # Destroy it
+  my $destroy_res = $jmap_tester->request([
+    [ setUsers => {
+      destroy => [ $first_id ],
+    } ],
+  ]);
+
+  is(
+    $destroy_res->single_sentence->as_set->destroyed_ids,
+    1,
+    'destroyed first user'
+  );
+
+  my $update_res = $jmap_tester->request([
+    [ setUsers => {
+      update => {
+        $first_id => { username => 'buser' },
+      },
+    } ]
+  ]);
+
+  jcmp_deeply(
+    $update_res->single_sentence->arguments->{notUpdated},
+    {
+      $first_id => {
+        'description' => 'no such record found',
+        'type' => 'notFound'
+      },
+    },
+    "cannot update a destroyed record"
+  );
+};
+
 done_testing;


### PR DESCRIPTION
This search:

  ->find({
    id            => $id,
    accountId     => $accountId,
    dateDestroyed => $date,
  })

actually only searches on 'id'!

The documentation to ->find() does not inspire confidence, let's
just not use it.

The attached test failed previously but now passes.