### PR TITLE
Match duplicate key exceptions more broadly

### DIFF
--- a/lib/Ix/DBIC/ResultSet.pm
+++ b/lib/Ix/DBIC/ResultSet.pm
@@ -419,7 +419,7 @@ sub ix_create ($self, $ctx, $to_create) {
 
       unless ($row or $error) {
         # Mask duplicate key errors nicely
-        if ($exception =~ /\ADBIx.*ERROR:\s+duplicate key/) {
+        if ($exception =~ /\ADBI.*ERROR:\s+duplicate key/) {
           return (
             undef,
             $ctx->error(invalidRecord => {
@@ -766,7 +766,7 @@ sub ix_update ($self, $ctx, $to_update) {
       );
 
       unless ($ok or $error) {
-        if ($exception =~ /\ADBIx.*ERROR:\s+duplicate key/) {
+        if ($exception =~ /\ADBI.*ERROR:\s+duplicate key/) {
           return (
             undef,
             $ctx->error(invalidRecord => {


### PR DESCRIPTION
DBIx::Class may not be in the exception string. DBI should be
though!