### PR TITLE
Fail to compile if classes have filters that cannot be diffed

### DIFF
--- a/t/get_foo_list.t
+++ b/t/get_foo_list.t
@@ -1360,7 +1360,7 @@ subtest "distinct rows only" => sub {
 
   # This causes our generated SQL to allow for duplicate rows which
   # can happen in downstream consumers
-  $ENV{RECIPEID_NOT_REQUIRED} = 1;
+  local $ENV{RECIPEID_NOT_REQUIRED} = 1;
 
   delete $cake_id{chocolate1};
 
@@ -1411,6 +1411,7 @@ subtest "tooManyChanges" => sub {
   subtest "Plenty of space for more changes" => sub {
     my $res = $jmap_tester->request([[
       getCakeListUpdates => {
+        filter => { recipeId => $secret1_recipe_id, },
         sinceState => 1,
         maxChanges => 100,
       },
@@ -1429,6 +1430,7 @@ subtest "tooManyChanges" => sub {
   subtest "Exact amount of changes" => sub {
     my $res = $jmap_tester->request([[
       getCakeListUpdates => {
+        filter => { recipeId => $secret1_recipe_id, },
         sinceState => 1,
         maxChanges => 3,
       },
@@ -1447,6 +1449,7 @@ subtest "tooManyChanges" => sub {
   subtest "Not enough room for all the changes" => sub {
     my $res = $jmap_tester->request([[
       getCakeListUpdates => {
+        filter => { recipeId => $secret1_recipe_id, },
         sinceState => 1,
         maxChanges => 2,
       },
@@ -1458,6 +1461,19 @@ subtest "tooManyChanges" => sub {
       'got correct error'
     ) or diag explain $res->as_stripped_struct;
   };
+};
+
+subtest "custom cake differ" => sub {
+  # Make sure we can get updates with this filter/custom differ
+  my $res = $jmap_tester->request([
+    [ getCakeListUpdates => { filter => {
+        recipeId => $secret1_recipe_id,
+        isLayered             => jtrue,
+        'recipe.is_delicious' => jtrue,
+      }, sinceState => 0 }
+    ],
+  ]);
+  ok($res->http_response->is_success, 'call succeeded');
 };
 
 done_testing;

--- a/t/lib/Bakesale/Schema/Result/Cake.pm
+++ b/t/lib/Bakesale/Schema/Result/Cake.pm
@@ -216,6 +216,19 @@ sub ix_get_list_filter_map {
         return $is_layered ? { layer_count => { '>'  => 1 } }
                            : { layer_count => { '<=' => 1 } };
       },
+      differ => sub ($entity, $filter) {
+        # It differs if it's layered when isLayered is false,
+        # or if it's not layered when isLayered is true
+        my $diff;
+
+        if ($filter) {
+          $diff = 1 if $entity->layer_count <= 1;
+        } else {
+          $diff = 1 if $entity->layer_count > 1;
+        }
+
+        return $diff;
+      },
     },
     'recipe.is_delicious' => { },
   };


### PR DESCRIPTION
If a class specifies a filter that doesn't:

 - match an ix property on the class
 - provide its own differ subroutine
 - refer to a joined relationship

then fail to compile mentioning why.

This saves consumers trouble down the road if they implement
a filter that doesn't match up to an Ix property but don't provide
a custom differ. When this would happen, Ix would crash during
ix_get_list_updates() when trying to compare rows against filters.