### PR TITLE
canonicalizers and array types

### DIFF
--- a/lib/Ix/DBIC/Result.pm
+++ b/lib/Ix/DBIC/Result.pm
@@ -104,6 +104,8 @@ my %IX_TYPE = (
   istring      => { data_type => 'citext' },
   timestamptz  => { data_type => 'timestamptz' },
 
+  'string[]'   => { data_type => 'text[]' },
+
   boolean      => { data_type => 'boolean' },
   integer      => { data_type => 'integer', is_numeric => 1 },
   idstr        => { data_type => 'uuid', },

--- a/lib/Ix/DBIC/Result.pm
+++ b/lib/Ix/DBIC/Result.pm
@@ -104,8 +104,9 @@ my %IX_TYPE = (
   istring      => { data_type => 'citext' },
   timestamptz  => { data_type => 'timestamptz' },
 
+  # We don't provide istring[] because DBD::Pg doesn't work nicely with it yet:
+  # https://rt.cpan.org/Public/Bug/Display.html?id=54224
   'string[]'   => { data_type => 'text[]' },
-  'istring[]'  => { data_type => 'citext[]' },
 
   boolean      => { data_type => 'boolean' },
   integer      => { data_type => 'integer', is_numeric => 1 },

--- a/lib/Ix/DBIC/Result.pm
+++ b/lib/Ix/DBIC/Result.pm
@@ -105,6 +105,7 @@ my %IX_TYPE = (
   timestamptz  => { data_type => 'timestamptz' },
 
   'string[]'   => { data_type => 'text[]' },
+  'istring[]'  => { data_type => 'citext[]' },
 
   boolean      => { data_type => 'boolean' },
   integer      => { data_type => 'integer', is_numeric => 1 },

--- a/lib/Ix/DBIC/ResultSet.pm
+++ b/lib/Ix/DBIC/ResultSet.pm
@@ -384,6 +384,7 @@ sub ix_create ($self, $ctx, $to_create) {
       %$properties,
 
       accountId => $accountId,
+      isActive  => 1,
       modSeqCreated => $next_state,
       modSeqChanged => $next_state,
     );

--- a/lib/Ix/Validators.pm
+++ b/lib/Ix/Validators.pm
@@ -9,8 +9,19 @@ use Ix::Util qw($ix_id_re);
 use experimental qw(lexical_subs postderef signatures);
 
 use Sub::Exporter -setup => [ qw(
+  array_of
   boolean email enum domain idstr integer nonemptystr simplestr freetext state
 ) ];
+
+sub array_of ($validator) {
+  return sub ($x, @) {
+    my @errors = grep {; defined } map {; $validator->($_) } @$x;
+    return unless @errors;
+
+    # Sort of pathetic. -- rjbs, 2017-05-10
+    return "invalid values in array";
+  };
+}
 
 sub boolean {
   return sub ($x, @) {

--- a/t/lib/Bakesale/Schema/Result/Cookie.pm
+++ b/t/lib/Bakesale/Schema/Result/Cookie.pm
@@ -15,7 +15,10 @@ __PACKAGE__->table('cookies');
 __PACKAGE__->ix_add_columns;
 
 __PACKAGE__->ix_add_properties(
-  type       => { data_type => 'string', },
+  type       => {
+    data_type     => 'string',
+    canonicalizer => sub ($value) { $value =~ s/ cookie\z//r; },
+  },
   batch      => { data_type => 'integer', is_immutable => 1 },
   baked_at   => { data_type => 'timestamptz', is_optional => 1 },
   expires_at => { data_type => 'timestamptz', is_optional => 0 },


### PR DESCRIPTION
This adds:

1. a metaproperty for saying "when updating or creating an entity, this property should be munged by this subroutine"
2. support for `string[]` type