### PR TITLE
split is_immutable into client_may_init and client_may_update

### DIFF
--- a/lib/Ix/DBIC/ResultSet.pm
+++ b/lib/Ix/DBIC/ResultSet.pm
@@ -320,7 +320,7 @@ sub ix_create ($self, $ctx, $to_create) {
   my %result;
 
   # TODO do this once during ix_finalize -- rjbs, 2016-05-10
-  my %is_user_prop = map {; $_ => 1 } $rclass->ix_mutable_properties($ctx);
+  my %is_user_prop = map {; $_ => 1 } $rclass->ix_client_init_ok_properties($ctx);
 
   my $prop_info = $rclass->ix_property_info;
 
@@ -685,7 +685,7 @@ sub ix_update ($self, $ctx, $to_update) {
 
   my %updated;
 
-  my %is_user_prop = map {; $_ => 1 } $rclass->ix_mutable_properties($ctx);
+  my %is_user_prop = map {; $_ => 1 } $rclass->ix_client_update_ok_properties($ctx);
   my $prop_info = $rclass->ix_property_info;
 
   state $bad_idstr = idstr();
@@ -1169,9 +1169,13 @@ sub ix_get_list_updates ($self, $ctx, $arg = {}) {
     # Query on all immutable fields that were passed in to the filter to
     # condense our list of possible changes; otherwise we may end up querying
     # the entire table.
+    #
+    # XXX This exposes the fact that we said "immutable" but really meant
+    # "can't be set by client."  Some properties were marked immutable but
+    # could actually be updated by the server. -- rjbs, 2017-07-11
     my $filter_map = $rclass->ix_get_list_filter_map;
     my $prop_info = $rclass->ix_property_info;
-    my %is_user_prop = map {; $_ => 1 } $rclass->ix_mutable_properties($ctx);
+    my %is_user_prop = map {; $_ => 1 } $rclass->ix_client_update_ok_properties($ctx);
 
     my %immutable = map {;
       my $prop = $_ =~ /\./ ? $_ : "me.$_"; # me.<...>

--- a/t/lib/Bakesale/Schema/Result/Cake.pm
+++ b/t/lib/Bakesale/Schema/Result/Cake.pm
@@ -16,7 +16,7 @@ __PACKAGE__->ix_add_columns;
 __PACKAGE__->ix_add_properties(
   type        => { data_type => 'string',     },
   layer_count => { data_type => 'integer',  validator => integer(1, 10)  },
-  baked_at    => { data_type => 'timestamptz', is_immutable => 1 },
+  baked_at    => { data_type => 'timestamptz', client_may_init => 0, client_may_update => 0 },
   recipeId    => {
     data_type    => 'idstr',
     xref_to      => 'cakeRecipes',

--- a/t/lib/Bakesale/Schema/Result/Cookie.pm
+++ b/t/lib/Bakesale/Schema/Result/Cookie.pm
@@ -19,7 +19,7 @@ __PACKAGE__->ix_add_properties(
     data_type     => 'string',
     canonicalizer => sub ($value) { $value =~ s/ cookie\z//r; },
   },
-  batch      => { data_type => 'integer', is_immutable => 1 },
+  batch      => { data_type => 'integer', client_may_init => 0, client_may_update => 0 },
   baked_at   => { data_type => 'timestamptz', is_optional => 1 },
   expires_at => { data_type => 'timestamptz', is_optional => 0 },
   delicious  => { data_type => 'string', is_optional => 0 },
@@ -39,7 +39,7 @@ sub ix_postprocess_set { $next_batch++ }
 
 sub ix_default_properties {
   return {
-    baked_at  => Ix::DateTime->now,
+    baked_at   => Ix::DateTime->now,
     expires_at => Ix::DateTime->now->add(days => 3),
     delicious  => 'yes',
     batch      => sub { $next_batch }


### PR DESCRIPTION
* init is for setting things while creating
* update is for setting things via an update

I think we should bring back is_immutable, sometime, to indicate that
the field is guaranteed to never change.