### PR TITLE
ix_get_list_updates - don't include rows that haven't changed

### DIFF
--- a/lib/Ix/DBIC/ResultSet.pm
+++ b/lib/Ix/DBIC/ResultSet.pm
@@ -1240,7 +1240,12 @@ sub ix_get_list_updates ($self, $ctx, $arg = {}) {
 
       my $was_removed = ! $entity->isActive && ! $is_changed;
 
-      if ($is_removed && ! $is_new && ! $was_removed) {
+      if ($entity->modSeqChanged <= $since_state) {
+        # Don't include the row. It hasn't been modified since our
+        # requested state, so there's no reason to show it. But we
+        # might still need to inc $i below so we properly track
+        # the location of elements
+      } elsif ($is_removed && ! $is_new && ! $was_removed) {
         push @removed, "" . $entity->id;
         $count++;
       } elsif (! $is_removed && $is_new) {

--- a/t/get_foo_list.t
+++ b/t/get_foo_list.t
@@ -1332,11 +1332,7 @@ subtest "differ boolean comparison when db row is false" => sub {
         },
         'newState' => $state,
         'oldState' => $state - 2,
-        'removed' => set(
-          $cake_id{marble1},
-          $cake_id{marble2},
-          $cake_id{lemon1},
-        ),
+        'removed' => [],
         'sort' => [
           'type asc'
         ],


### PR DESCRIPTION
If we're requesting updates since state 5, it doesn't make sense
to include things that were last modified at state 5 or below.