### PR TITLE
cache a schema connection to re-use in subsequent calls to PSGI sub

### DIFF
--- a/t/access_log.t
+++ b/t/access_log.t
@@ -171,4 +171,6 @@ for my $line (@lines) {
   );
 }
 
+$app->_shutdown;
+
 done_testing;

--- a/t/basic.t
+++ b/t/basic.t
@@ -2270,4 +2270,6 @@ subtest "argument validation" => sub {
   );
 };
 
+$app->_shutdown;
+
 done_testing;

--- a/t/get_foo_list.t
+++ b/t/get_foo_list.t
@@ -1497,5 +1497,6 @@ subtest "we do not promote undef sort or filter" => sub {
   }
 };
 
-done_testing;
+$app->_shutdown;
 
+done_testing;

--- a/t/lib/Bakesale.pm
+++ b/t/lib/Bakesale.pm
@@ -192,19 +192,19 @@ package Bakesale {
   sub get_context ($self, $arg) {
     Bakesale::Context->new({
       userId    => $arg->{userId},
-      schema    => $self->schema_connection,
+      schema    => $arg->{schema} // $self->schema_connection,
       processor => $self,
     });
   }
 
-  sub get_system_context ($self) {
+  sub get_system_context ($self, $arg = {}) {
     Bakesale::Context::System->new({
-      schema    => $self->schema_connection,
+      schema    => $arg->{schema} // $self->schema_connection,
       processor => $self,
     });
   }
 
-  sub context_from_plack_request ($self, $req) {
+  sub context_from_plack_request ($self, $req, $arg = {}) {
     if (my $user_id = $req->cookies->{bakesaleUserId}) {
       $user_id =~ s/"(.*)"/$1/;
 
@@ -214,7 +214,10 @@ package Bakesale {
         });
       }
 
-      return $self->get_context({ userId => $user_id });
+      return $self->get_context({
+        schema => $arg->{schema},
+        userId => $user_id,
+      });
     }
 
     http_throw('Gone');

--- a/t/updates.t
+++ b/t/updates.t
@@ -538,4 +538,6 @@ subtest "getFooUpdates - ix_get_updates_check" => sub {
   }
 };
 
+$app->_shutdown;
+
 done_testing;


### PR DESCRIPTION
Each PSGI app (subroutine) gets its own cache, but the caches are
registered with the Ix::App object so that their caches can be cleared
as needed to prepare to shutdown the system.  In production, this is
unlikely to be needed, but in testing we don't want lingering db
connections at global destruction.  DBD::Pg gets grumpy and complains.

Calling $app->_shutdown in each test is inelegant, but the TestInstance
system (on another branch) ported from a downstream application can move
the shutdown into the TestInstance's demolish, making the cleanup happen
automatically in tests using a TestInstance.

Note:  Rik isn't 100% sure why undefining the app sub isn't sufficient
to clear the cache (in a world where we don't register caches with the
Ix::App object).  That may be worth looking into sometime.

With this change, the test suite drops nearly 200 connections in its
total run, as most tests run through a single app object created in the
test's prelude.  With a TestInstance, this will happen behind the
scenes.