### PR TITLE
is_immutable is back

### DIFF
--- a/lib/Ix/DBIC/Result.pm
+++ b/lib/Ix/DBIC/Result.pm
@@ -39,11 +39,16 @@ sub ix_client_update_ok_properties ($self, $ctx) {
   my $prop_info = $self->ix_property_info;
 
   if ($ctx->root_context->is_system) {
-    return keys %$prop_info;
+    return
+      grep {;    ! $prop_info->{$_}{is_virtual}
+              && ! $prop_info->{$_}{is_immutable} }
+      keys %$prop_info;
   }
 
   return
-    grep {; $prop_info->{$_}{client_may_update} && ! $prop_info->{$_}{is_virtual} }
+    grep {;      $prop_info->{$_}{client_may_update}
+            && ! $prop_info->{$_}{is_virtual}
+            && ! $prop_info->{$_}{is_immutable} }
     keys %$prop_info;
 }
 

--- a/t/lib/Bakesale/Schema/Result/Biscuit.pm
+++ b/t/lib/Bakesale/Schema/Result/Biscuit.pm
@@ -17,6 +17,7 @@ __PACKAGE__->ix_add_columns;
 __PACKAGE__->ix_add_properties(
   type => { data_type => 'string', client_may_init => 1, client_may_update => 0 },
   qty  => { data_type => 'integer', is_optional => 1, client_may_init => 0, client_may_update => 1 },
+  size => { data_type => 'string',  is_optional => 1, is_immutable => 1 },
 );
 
 __PACKAGE__->set_primary_key('id');


### PR DESCRIPTION
Now, is_immutable prevents even system context from changing
properties.  This should eliminate some repeated code and
may help improve getFooListUpdates.