### PR TITLE
handle_calls and results_so_far

### DIFF
--- a/lib/Ix/App/JMAP.pm
+++ b/lib/Ix/App/JMAP.pm
@@ -23,8 +23,8 @@ sub _core_request ($self, $ctx, $req) {
   }
 
   $req->env->{'ix.transaction'}{jmap}{calls} = $calls;
-  my $result  = $ctx->process_request( $calls );
-  my $json    = $self->encode_json($result);
+  my $result  = $ctx->handle_calls($calls, { no_implicit_client_ids => 1 });
+  my $json    = $self->encode_json($result->as_struct);
 
   return [
     200,

--- a/lib/Ix/Context.pm
+++ b/lib/Ix/Context.pm
@@ -67,6 +67,19 @@ sub get_created_id ($self, $type, $creation_id) {
   return $id;
 }
 
+has result_accumulator => (
+  init_arg  => undef,
+  predicate => 'is_handling_calls',
+  reader    => '_result_accumulator',
+);
+
+sub results_so_far ($self) {
+  $self->internal_error("tried to inspect results outside of request")->throw
+    unless $self->is_handling_calls;
+
+  return $self->_result_accumulator;
+}
+
 sub handle_calls ($self, $calls, $arg = {}) {
   $self->processor->handle_calls($self, $calls, $arg);
 }

--- a/lib/Ix/Context.pm
+++ b/lib/Ix/Context.pm
@@ -67,6 +67,10 @@ sub get_created_id ($self, $type, $creation_id) {
   return $id;
 }
 
+sub handle_calls ($self, $calls, $arg = {}) {
+  $self->processor->handle_calls($self, $calls, $arg);
+}
+
 sub process_request ($self, $calls) {
   $self->processor->process_request($self, $calls);
 }

--- a/lib/Ix/Context/WithAccount.pm
+++ b/lib/Ix/Context/WithAccount.pm
@@ -34,6 +34,8 @@ has root_context => (
     internal_error
     result
 
+    results_so_far
+
     may_call
   ) ],
 );

--- a/lib/Ix/JMAP/SentenceBroker.pm
+++ b/lib/Ix/JMAP/SentenceBroker.pm
@@ -1,0 +1,47 @@
+use v5.24.0;
+package Ix::JMAP::SentenceBroker;
+
+use Moose;
+
+with 'JMAP::Tester::Role::SentenceBroker';
+
+use experimental 'signatures';
+
+use JMAP::Tester::Response::Sentence;
+use JMAP::Tester::Response::Paragraph;
+use JSON::Typist;
+
+sub client_ids_for_items ($self, $items) {
+  map {; $_->[1] } @$items
+}
+
+sub sentence_for_item ($self, $item) {
+  JMAP::Tester::Response::Sentence->new({
+    name      => $item->[0]->result_type,
+    arguments => $item->[0]->result_arguments,
+    client_id => $item->[1],
+
+    sentence_broker => $self,
+  });
+}
+
+sub paragraph_for_items {
+  my ($self, $items) = @_;
+
+  return JMAP::Tester::Response::Paragraph->new({
+    sentences => [
+      map {; $self->sentence_for_item($_) } @$items
+    ],
+  });
+}
+
+sub abort_callback       { sub { ... } };
+
+sub strip_json_types {
+  state $typist = JSON::Typist->new;
+  $typist->strip_types($_[1]);
+}
+
+no Moose;
+
+1;

--- a/lib/Ix/JMAP/SentenceCollection.pm
+++ b/lib/Ix/JMAP/SentenceCollection.pm
@@ -1,0 +1,39 @@
+use v5.24.0;
+package Ix::JMAP::SentenceCollection;
+
+use Moose;
+
+use experimental 'signatures';
+
+with 'JMAP::Tester::Role::SentenceCollection';
+
+use Ix::JMAP::SentenceBroker;
+sub sentence_broker {
+  state $BROKER = Ix::JMAP::SentenceBroker->new;
+}
+
+# [ [ $result, $cid ], ... ]
+has result_client_id_pairs => (
+  reader => '_result_client_id_pairs',
+);
+
+sub results ($self) {
+  map {; $_->[0] } $self->_result_client_id_pairs->@*;
+}
+
+sub has_errors {
+  ($_->[0]->does('Ix::Error') && return 1) for $_[0]->_result_client_id_pairs;
+  return;
+}
+
+sub result ($self, $n) {
+  Carp::confess("there is no result for index $n")
+    unless my $pair = $self->_result_client_id_pairs->[$n];
+  return $pair->[0];
+}
+
+sub items ($self) { $self->_result_client_id_pairs->@* }
+
+no Moose;
+
+1;

--- a/lib/Ix/JMAP/SentenceCollection.pm
+++ b/lib/Ix/JMAP/SentenceCollection.pm
@@ -14,7 +14,8 @@ sub sentence_broker {
 
 # [ [ $result, $cid ], ... ]
 has result_client_id_pairs => (
-  reader => '_result_client_id_pairs',
+  reader  => '_result_client_id_pairs',
+  default => sub {  []  },
 );
 
 sub results ($self) {
@@ -33,6 +34,11 @@ sub result ($self, $n) {
 }
 
 sub items ($self) { $self->_result_client_id_pairs->@* }
+
+sub add_items ($self, $items) {
+  push $self->_result_client_id_pairs->@*, @$items;
+  return;
+}
 
 no Moose;
 

--- a/lib/Ix/Processor/JMAP.pm
+++ b/lib/Ix/Processor/JMAP.pm
@@ -164,12 +164,9 @@ sub handle_calls ($self, $ctx, $calls) {
 }
 
 sub process_request ($self, $ctx, $calls) {
-  my $rset = $self->handle_calls($ctx, $calls);
+  my $sc = $self->handle_calls($ctx, $calls);
 
-  return [
-    map {; [ $_->[0]->result_type, $_->[0]->result_arguments, $_->[1] ] }
-    $rset->_result_client_id_pairs->@*
-  ];
+  return $sc->as_struct;
 }
 
 1;

--- a/t/lib/Bakesale.pm
+++ b/t/lib/Bakesale.pm
@@ -226,11 +226,24 @@ package Bakesale {
   sub schema_class { 'Bakesale::Schema' }
 
   sub handler_for ($self, $method) {
+    return 'result_count'  if $method eq 'countResults';
     return 'count_chars'   if $method eq 'countChars';
     return 'pie_type_list' if $method eq 'pieTypes';
     return 'bake_pies'     if $method eq 'bakePies';
     return 'validate_args' if $method eq 'validateArguments';
     return;
+  }
+
+  sub result_count ($self, $ctx, $arg) {
+    my $sc = $ctx->results_so_far;
+
+    my $s_count = $sc->sentences;
+    my $p_count = $sc->paragraphs;
+
+    return Ix::Result::Generic->new({
+      result_type       => 'resultCount',
+      result_arguments  => { sentences => $s_count, paragraphs => $p_count },
+    });
   }
 
   sub count_chars ($self, $ctx, $arg) {

--- a/t/processor/basic.t
+++ b/t/processor/basic.t
@@ -38,6 +38,43 @@ my $ctx = $Bakesale->get_context({
 
 {
   my $res = $ctx->process_request([
+    [ pieTypes => { tasty => 1 } ],
+    [ pieTypes => { tasty => 0 } ],
+    [ pieTypes => { tasty => 1 }, 'a' ],
+  ]);
+
+  my $ci_re = re(qr/\A x [0-9]{1,4} \z/x);
+  cmp_deeply(
+    $res,
+    [
+      [ pieTypes => { flavors => [ qw(pumpkin apple pecan) ] }, $ci_re ],
+      [ pieTypes => { flavors => [ qw(pumpkin apple pecan cherry eel) ] }, $ci_re ],
+      [ pieTypes => { flavors => [ qw(pumpkin apple pecan) ] }, 'a' ],
+    ],
+    "implicit client ids are added as needed",
+  ) or diag explain($res);
+}
+
+{
+  my $res = eval {
+    $ctx->handle_calls([
+      [ pieTypes => { tasty => 1 } ],
+      [ pieTypes => { tasty => 0 } ],
+      [ pieTypes => { tasty => 1 }, 'a' ],
+    ], { no_implicit_client_ids => 1 })->as_struct;
+  };
+
+  my $error = $@;
+
+  like(
+    $error,
+    qr{missing client id},
+    "if unfixed, request without client ids are rejected",
+  );
+}
+
+{
+  my $res = $ctx->process_request([
     [ pieTypes => { tasty => 1 }, 'a' ],
     [ bakePies => { tasty => 1, pieTypes => [ qw(apple eel pecan) ] }, 'b' ],
     [ pieTypes => { tasty => 0 }, 'c' ],

--- a/t/processor/basic.t
+++ b/t/processor/basic.t
@@ -695,4 +695,15 @@ subtest "invalid sinceState" => sub {
   );
 }
 
+subtest "results outside of request" => sub {
+  eval { local $ENV{QUIET_BAKESALE} = 1; $ctx->results_so_far };
+
+  my $error = $@;
+  like(
+    $error,
+    qr{tried to inspect},
+    "can't call ->results_so_far outside req",
+  );
+};
+
 done_testing;


### PR DESCRIPTION
There are three distinct but related changes in this branch.

1.  it implements the [SentenceCollection role](https://github.com/fastmail/JMAP-Tester/pull/29)
2.  contexts gain a results_so_far method
3.  the JMAP processor's process_request is obsoleted by handle_calls

Implementing SentenceCollection means that as we're handling each method in the call, we store the Ix::Result object until the end of all methods, at which point the final collection of results can be packed for serialization by Ix::App.

results_so_far means that a method handler can see the results of methods already called.  This is mostly so we can implement backrefs (JMAP spec, ResultReference), but it may have other uses.  Having the sentence collection implementation means that the results-so-far are much easier to deal with.

handle_calls is almost exactly the same as process_request, but it returns a sentence collection rather than a reference to an array of packed results.  Since Ix::Result objects might be specialized beyond being containers for unblessed structures, this means that handling a nested call should be less obnoxious.  (Previously, standard practice was either to look up the coderef for the handler and call it manually or to use `process_request` and then look at something ugly like `$res[1][0]`.

process_request is still present, and is a very small wrapper around handle_calls.