### PR TITLE
add methods for pre-limited resultsets

### DIFF
--- a/lib/Ix/Context.pm
+++ b/lib/Ix/Context.pm
@@ -19,6 +19,20 @@ has schema => (
   required => 1,
 );
 
+sub global_rs ($self, $rs_name) {
+  my $rs = $self->schema->resultset($rs_name);
+
+  if ($rs->result_class->isa('Ix::DBIC::Result')) {
+    $rs = $rs->search({ 'me.isActive' => 1 });
+  }
+
+  return $rs;
+}
+
+sub global_rs_including_inactive ($self, $rs_name) {
+  $self->schema->resultset($rs_name);
+}
+
 has processor => (
   is   => 'ro',
   does => 'Ix::Processor',

--- a/lib/Ix/Context.pm
+++ b/lib/Ix/Context.pm
@@ -17,21 +17,8 @@ sub root_context ($self) { $self }
 has schema => (
   is   => 'ro',
   required => 1,
+  handles  => [ qw( global_rs global_rs_including_inactive ) ],
 );
-
-sub global_rs ($self, $rs_name) {
-  my $rs = $self->schema->resultset($rs_name);
-
-  if ($rs->result_class->isa('Ix::DBIC::Result')) {
-    $rs = $rs->search({ 'me.isActive' => 1 });
-  }
-
-  return $rs;
-}
-
-sub global_rs_including_inactive ($self, $rs_name) {
-  $self->schema->resultset($rs_name);
-}
 
 has processor => (
   is   => 'ro',

--- a/lib/Ix/DBIC/AccountResult.pm
+++ b/lib/Ix/DBIC/AccountResult.pm
@@ -1,0 +1,27 @@
+use 5.20.0;
+use warnings;
+package Ix::DBIC::AccountResult;
+
+use parent 'DBIx::Class';
+
+use experimental qw(signatures postderef);
+
+sub account_rs ($self, $rs_name) {
+  my $rs = $self->result_source->schema->resultset($rs_name)->search({
+    'me.accountId' => $self->accountId,
+  });
+
+  if ($rs->result_class->isa('Ix::DBIC::Result')) {
+    $rs = $rs->search({ 'me.isActive' => 1 });
+  }
+
+  return $rs;
+}
+
+sub account_rs_including_inactive ($self, $rs_name) {
+  return $self->result_source->schema->resultset($rs_name)->search({
+    'me.accountId' => $self->accountId,
+  });
+}
+
+1;

--- a/lib/Ix/DBIC/Result.pm
+++ b/lib/Ix/DBIC/Result.pm
@@ -11,6 +11,8 @@ use Ix::Validators;
 use Ix::Util qw(ix_new_id);
 use JSON::MaybeXS;
 
+__PACKAGE__->load_components(qw/+Ix::DBIC::AccountResult/);
+
 sub ix_account_type { Carp::confess("ix_account_type not implemented") }
 
 # Checked for in ix_finalize

--- a/lib/Ix/DBIC/ResultSet.pm
+++ b/lib/Ix/DBIC/ResultSet.pm
@@ -886,7 +886,6 @@ sub ix_destroy ($self, $ctx, $to_destroy) {
 
 sub get_collection_lock ($self, $ctx) {
   my $schema = $ctx->schema;
-  my $accountId = $ctx->accountId;
   my $type_key = $self->_ix_rclass->ix_type_key;
 
   return try {
@@ -894,12 +893,11 @@ sub get_collection_lock ($self, $ctx) {
     # account ID.
 
     # XXX - Ask rclass what else we should lock at this point
-    my $locked = $schema->resultset('State')->search(
+    my $locked = $ctx->account_rs('State')->search(
       {
-        accountId => $accountId,
-        type      => $type_key,
+        type  => $type_key,
       }, {
-        for => 'update',
+        for   => 'update',
       }
     )->single;
 

--- a/lib/Ix/DBIC/Schema.pm
+++ b/lib/Ix/DBIC/Schema.pm
@@ -42,4 +42,18 @@ sub deploy {
   $self->DBIx::Class::Schema::deploy(@_)
 }
 
+sub global_rs ($self, $rs_name) {
+  my $rs = $self->resultset($rs_name);
+
+  if ($rs->result_class->isa('Ix::DBIC::Result')) {
+    $rs = $rs->search({ 'me.isActive' => 1 });
+  }
+
+  return $rs;
+}
+
+sub global_rs_including_inactive ($self, $rs_name) {
+  $self->resultset($rs_name);
+}
+
 1;


### PR DESCRIPTION
This adds:

* account_rs
* global_rs
* account_rs_including_inactive
* global_rs_including_inactive

It also adds Ix::DBIC::AccountResult, for a result class that is not an entity but does have an accountId field and should be able to provide `account_rs*` methods.

These methods provide recordsets for the named collection, but also add stipulate whether `isActive` must be true and whether `accountId` must match the account of the invocant.

In general, all Ix applications should be writable with limited, if any, recourse to calling `resultset` directly.