### PR TITLE
New-style JMAP

### DIFF
--- a/lib/Ix/Context.pm
+++ b/lib/Ix/Context.pm
@@ -150,6 +150,10 @@ sub result ($ctx, $type, $prop = {}) {
   });
 }
 
+sub result_without_accountid ($ctx, $type, $prop = {}) {
+  return $ctx->result($type, $prop);
+}
+
 sub may_call { 1 }
 
 1;

--- a/lib/Ix/Context/WithAccount.pm
+++ b/lib/Ix/Context/WithAccount.pm
@@ -36,7 +36,6 @@ has root_context => (
 
     error
     internal_error
-    result
 
     results_so_far
 
@@ -170,6 +169,18 @@ sub with_account ($self, $account_type, $accountId) {
   }
 
   $self->internal_error("conflicting recontextualization")->throw;
+}
+
+sub result ($self, $type, $prop = {}) {
+  $self->internal_error("got conflicting accountIds")
+    if (exists $prop->{accountId} && $prop->{accountId} ne $self->accountId);
+
+  $prop->{accountId} = $self->accountId;
+  return $self->root_context->result($type, $prop);
+}
+
+sub result_without_accountid ($self, $type, $prop={}) {
+  return $self->root_context->result($type, $prop);
 }
 
 1;

--- a/lib/Ix/DBIC/Result.pm
+++ b/lib/Ix/DBIC/Result.pm
@@ -18,10 +18,6 @@ sub ix_account_type { Carp::confess("ix_account_type not implemented") }
 # Checked for in ix_finalize
 # sub ix_type_key { }
 
-sub ix_type_key_singular ($self) {
-  $self->ix_type_key =~ s/s\z//r;
-}
-
 sub ix_get_list_enabled {}
 sub ix_extra_get_args { }
 

--- a/lib/Ix/DBIC/Result.pm
+++ b/lib/Ix/DBIC/Result.pm
@@ -214,7 +214,6 @@ sub ix_finalize ($class) {
     for my $method (qw(
       ix_get_list_check
       ix_get_list_updates_check
-      ix_get_list_fetchable_map
       ix_get_list_filter_map
       ix_get_list_sort_map
       ix_get_list_joins

--- a/lib/Ix/DBIC/Result.pm
+++ b/lib/Ix/DBIC/Result.pm
@@ -338,6 +338,10 @@ sub ix_highest_state ($self, $since, $rows) {
   return $rows->[-1]{$state_string_field};
 }
 
+sub ix_item_created_since ($self, $item, $since) {
+  return $item->{modSeqCreated} > $since;
+}
+
 sub ix_update_single_state_conds ($self, $example_row) {
   return { 'me.modSeqChanged' => $example_row->{modSeqChanged} }
 }

--- a/lib/Ix/DBIC/ResultSet.pm
+++ b/lib/Ix/DBIC/ResultSet.pm
@@ -1069,7 +1069,7 @@ sub ix_get_list ($self, $ctx, $arg = {}) {
       state        => $hms,
       total        => $total,
       position     => $arg->{position} // 0,
-      "${key1}Ids" => [ map {; "" . $_->{id} } @items ],  # XXX -- michael, 2018-05-09
+      ids          => [ map {; "" . $_->{id} } @items ],  # XXX -- michael, 2018-05-09
 
       canCalculateUpdates => \1,
     });

--- a/lib/Ix/DBIC/ResultSet.pm
+++ b/lib/Ix/DBIC/ResultSet.pm
@@ -117,6 +117,7 @@ sub ix_get ($self, $ctx, $arg = {}) {
       $arg,
       [
         $ctx->result($rclass->ix_type_key . "/get" => {
+          accountId => $ctx->accountId,
           state => $rclass->ix_state_string($ctx->state),
           list  => \@rows,
           notFound => (@not_found ? \@not_found : undef),
@@ -157,6 +158,7 @@ sub ix_get_updates ($self, $ctx, $arg = {}) {
 
     if ($statecmp->is_in_sync) {
       return $ctx->result($res_type => {
+        accountId => $ctx->accountId,
         oldState => "$since",
         newState => "$since",
         hasMoreUpdates => JSON::MaybeXS::JSON->false(), # Gross. -- rjbs, 2017-02-13
@@ -249,6 +251,7 @@ sub ix_get_updates ($self, $ctx, $arg = {}) {
     @changed = uniq @changed;
 
     my @return = $ctx->result($res_type => {
+      accountId => $ctx->accountId,
       oldState => "$since",
       newState => ($hasMoreUpdates
                 ? $rclass->ix_highest_state($since, \@rows)
@@ -980,6 +983,7 @@ sub ix_set ($self, $ctx, $arg = {}) {
       result_type => "$type_key/set",
       old_state => $curr_state,
       new_state => $rclass->ix_state_string($state),
+      accountId => $ctx->accountId,
       %result,
     }) ];
 
@@ -1040,6 +1044,7 @@ sub ix_get_list ($self, $ctx, $arg = {}) {
     my $hms = "" . $ctx->state->highest_modseq_for($key);
 
     my @res = $ctx->result("$key/query" => {
+      accountId    => $ctx->accountId,
       filter       => $orig_filter,
       sort         => $orig_sort,
       queryState   => $hms,
@@ -1107,6 +1112,7 @@ sub ix_get_list_updates ($self, $ctx, $arg = {}) {
       # Nothing changed!  But we still promise to return the total,
       # unfortunately, so we get it. -- rjbs, 2016-04-13
       return $ctx->result("$key/queryChanges" => {
+        accountId => $ctx->accountId,
         filter => $orig_filter,
         sort   => $orig_sort,
         oldQueryState => "$since_state",
@@ -1222,6 +1228,7 @@ sub ix_get_list_updates ($self, $ctx, $arg = {}) {
     }
 
     return $ctx->result("$key/queryChanges" => {
+      accountId => $ctx->accountId,
       filter => $orig_filter,
       sort   => $orig_sort,
       oldQueryState => "" . $since_state,

--- a/lib/Ix/DBIC/ResultSet.pm
+++ b/lib/Ix/DBIC/ResultSet.pm
@@ -117,7 +117,6 @@ sub ix_get ($self, $ctx, $arg = {}) {
       $arg,
       [
         $ctx->result($rclass->ix_type_key . "/get" => {
-          accountId => $ctx->accountId,
           state => $rclass->ix_state_string($ctx->state),
           list  => \@rows,
           notFound => (@not_found ? \@not_found : undef),
@@ -158,7 +157,6 @@ sub ix_get_updates ($self, $ctx, $arg = {}) {
 
     if ($statecmp->is_in_sync) {
       return $ctx->result($res_type => {
-        accountId => $ctx->accountId,
         oldState => "$since",
         newState => "$since",
         hasMoreUpdates => JSON::MaybeXS::JSON->false(), # Gross. -- rjbs, 2017-02-13
@@ -255,7 +253,6 @@ sub ix_get_updates ($self, $ctx, $arg = {}) {
     @updated   = uniq @updated;
 
     my @return = $ctx->result($res_type => {
-      accountId => $ctx->accountId,
       oldState => "$since",
       newState => ($hasMoreUpdates
                 ? $rclass->ix_highest_state($since, \@rows)
@@ -1049,7 +1046,6 @@ sub ix_get_list ($self, $ctx, $arg = {}) {
     my $hms = "" . $ctx->state->highest_modseq_for($key);
 
     my @res = $ctx->result("$key/query" => {
-      accountId    => $ctx->accountId,
       filter       => $orig_filter,
       sort         => $orig_sort,
       queryState   => $hms,
@@ -1117,7 +1113,6 @@ sub ix_get_list_updates ($self, $ctx, $arg = {}) {
       # Nothing changed!  But we still promise to return the total,
       # unfortunately, so we get it. -- rjbs, 2016-04-13
       return $ctx->result("$key/queryChanges" => {
-        accountId => $ctx->accountId,
         filter => $orig_filter,
         sort   => $orig_sort,
         oldQueryState => "$since_state",
@@ -1233,7 +1228,6 @@ sub ix_get_list_updates ($self, $ctx, $arg = {}) {
     }
 
     return $ctx->result("$key/queryChanges" => {
-      accountId => $ctx->accountId,
       filter => $orig_filter,
       sort   => $orig_sort,
       oldQueryState => "" . $since_state,

--- a/lib/Ix/DBIC/ResultSet.pm
+++ b/lib/Ix/DBIC/ResultSet.pm
@@ -147,7 +147,7 @@ sub ix_get_updates ($self, $ctx, $arg = {}) {
       return $error;
     }
 
-    my $type_key = $rclass->ix_type_key_singular;
+    my $type_key = $rclass->ix_type_key;
     my $schema   = $ctx->schema;
     my $res_type = "$type_key/changes";
 
@@ -998,7 +998,6 @@ sub ix_get_list ($self, $ctx, $arg = {}) {
 
   return $ctx->txn_do(sub {
     my $key = $rclass->ix_type_key;
-    my $key1 = $rclass->ix_type_key_singular;
     my $orig_filter = $arg->{filter};
     my $orig_sort   = $arg->{sort};
 
@@ -1061,7 +1060,6 @@ sub ix_get_list_updates ($self, $ctx, $arg = {}) {
 
   return $ctx->txn_do(sub {
     my $key = $rclass->ix_type_key;
-    my $key1 = $rclass->ix_type_key_singular;
 
     my $schema = $ctx->schema;
 
@@ -1205,11 +1203,11 @@ sub ix_get_list_updates ($self, $ctx, $arg = {}) {
         push @removed, "" . $entity->id;
         $count++;
       } elsif (! $is_removed && $is_new) {
-        push @added, { index => $i, "${key1}Id" => "" . $entity->id };
+        push @added, { index => $i, "id" => "" . $entity->id };
         $count++;
       } elsif (! $is_removed && $is_changed) {
         push @removed, "" . $entity->id;
-        push @added, { index => $i, "${key1}Id" => "" . $entity->id };
+        push @added, { index => $i, "id" => "" . $entity->id };
         $count += 2;
       }
 
@@ -1222,7 +1220,7 @@ sub ix_get_list_updates ($self, $ctx, $arg = {}) {
       $i++ unless $is_removed;
     }
 
-    return $ctx->result("$key1/queryChanges" => {
+    return $ctx->result("$key/queryChanges" => {
       filter => $orig_filter,
       sort   => $orig_sort,
       oldState => "" . $since_state,

--- a/lib/Ix/DBIC/ResultSet.pm
+++ b/lib/Ix/DBIC/ResultSet.pm
@@ -899,9 +899,9 @@ sub get_collection_lock ($self, $ctx) {
   } catch {
     # If the above failed, it was most likely due to a lock timeout
     # (if one was configured).
-    return $ctx->error('tryAgain' => {
+    $ctx->error('tryAgain' => {
       description => "blocked by another client",
-    });
+    })->throw;
   };
 }
 

--- a/lib/Ix/Processor/JMAP.pm
+++ b/lib/Ix/Processor/JMAP.pm
@@ -55,26 +55,25 @@ has _dbic_handlers => (
         }
       }
 
-      my $key  = $rclass->ix_type_key;
-      my $key1 = $rclass->ix_type_key_singular;
+      my $key = $rclass->ix_type_key;
 
-      $handler{"get\u$key"} = sub ($self, $ctx, $arg = {}) {
+      $handler{"$key/get"} = sub ($self, $ctx, $arg = {}) {
         $ctx->schema->resultset($moniker)->ix_get($ctx, $arg);
       };
 
-      $handler{"get\u${key1}Updates"} = sub ($self, $ctx, $arg = {}) {
+      $handler{"$key/changes"} = sub ($self, $ctx, $arg = {}) {
         $ctx->schema->resultset($moniker)->ix_get_updates($ctx, $arg);
       };
 
-      $handler{"set\u$key"} = sub ($self, $ctx, $arg) {
+      $handler{"$key/set"} = sub ($self, $ctx, $arg) {
         $ctx->schema->resultset($moniker)->ix_set($ctx, $arg);
       };
 
       if ($rclass->ix_get_list_enabled) {
-        $handler{"get\u${key1}List"} = sub ($self, $ctx, $arg) {
+        $handler{"$key/query"} = sub ($self, $ctx, $arg) {
           $ctx->schema->resultset($moniker)->ix_get_list($ctx, $arg);
         };
-        $handler{"get\u${key1}ListUpdates"} = sub ($self, $ctx, $arg) {
+        $handler{"$key/queryChanges"} = sub ($self, $ctx, $arg) {
           $ctx->schema->resultset($moniker)->ix_get_list_updates($ctx, $arg);
         };
       }

--- a/lib/Ix/Processor/JMAP.pm
+++ b/lib/Ix/Processor/JMAP.pm
@@ -200,7 +200,7 @@ sub handle_calls ($self, $ctx, $calls, $arg = {}) {
     unless (@rv) {
       @rv = try {
         unless ($ctx->may_call($method, $arg)) {
-          return $ctx->error(invalidPermissions => {
+          return $ctx->error(forbidden => {
             description => "you are not authorized to make this call",
           });
         }

--- a/lib/Ix/Result.pm
+++ b/lib/Ix/Result.pm
@@ -35,6 +35,8 @@ package Ix::Result::FoosSet {
 
   use namespace::autoclean;
 
+  has accountId   => (is => 'ro', isa => 'Str', required => 1);
+
   has result_type => (is => 'ro', isa => 'Str', required => 1);
 
   has result_arguments => (
@@ -42,6 +44,7 @@ package Ix::Result::FoosSet {
     lazy => 1,
     default => sub ($self) {
       my %prop = (
+        accountId => $self->accountId,
         oldState => $self->old_state,
         newState => $self->new_state,
 

--- a/t/access_log.t
+++ b/t/access_log.t
@@ -64,7 +64,7 @@ local @ENV{qw(NO_CAKE_TOPPERS QUIET_BAKESALE)} = (1, 1);
 print STDERR "Ignore the next two exception reports for now..\n";
 $res = $jmap_tester->request([
   [
-    setCakes => {
+    'Cake/set' => {
       create => {
         yum => { type => 'wedding', layer_count => 4, recipeId => $account{recipes}{1} },
         woo => { type => 'wedding', layer_count => 8, recipeId => $account{recipes}{1} },
@@ -77,7 +77,7 @@ cmp_deeply(
   $res->as_stripped_triples,
   [
     [
-      cakesSet => superhashof({
+      'Cake/set' => superhashof({
         notCreated => {
           woo => { guid => ignore(), type => 'internalError' },
           yum => { guid => ignore(), type => 'internalError' },
@@ -111,7 +111,7 @@ for my $line (@lines) {
       ) : (
         call_info => [
           [
-            setCakes => { elapsed_seconds => $elapsed_re },
+            'Cake/set' => { elapsed_seconds => $elapsed_re },
           ],
         ],
         exception_guids => [ re('[A-Z0-9-]+'), re('[A-Z0-9-]+') ],

--- a/t/access_log.t
+++ b/t/access_log.t
@@ -8,6 +8,7 @@ use lib 't/lib';
 use Bakesale;
 use Bakesale::App;
 use Bakesale::Schema;
+use Capture::Tiny qw(capture_stderr);
 use JSON::MaybeXS qw(decode_json);
 use Test::Deep;
 use Test::Deep::JType;
@@ -61,17 +62,18 @@ jcmp_deeply(
 # Get us some exceptions
 local @ENV{qw(NO_CAKE_TOPPERS QUIET_BAKESALE)} = (1, 1);
 
-print STDERR "Ignore the next two exception reports for now..\n";
-$res = $jmap_tester->request([
-  [
-    'Cake/set' => {
-      create => {
-        yum => { type => 'wedding', layer_count => 4, recipeId => $account{recipes}{1} },
-        woo => { type => 'wedding', layer_count => 8, recipeId => $account{recipes}{1} },
-      }
-    }, "my id"
-  ],
-]);
+capture_stderr(sub {
+  $res = $jmap_tester->request([
+    [
+      'Cake/set' => {
+        create => {
+          yum => { type => 'wedding', layer_count => 4, recipeId => $account{recipes}{1} },
+          woo => { type => 'wedding', layer_count => 8, recipeId => $account{recipes}{1} },
+        }
+      }, "my id"
+    ],
+  ]);
+});
 
 cmp_deeply(
   $res->as_stripped_triples,

--- a/t/basic.t
+++ b/t/basic.t
@@ -2020,7 +2020,7 @@ subtest "space cookies (are totally canceled)" => sub {
   ]]);
   jcmp_deeply(
     $res->single_sentence->arguments->{type},
-    'invalidPermissions',
+    'forbidden',
     'you are not authorized to make this call'
   );
 };

--- a/t/basic.t
+++ b/t/basic.t
@@ -568,7 +568,13 @@ subtest "make a recipe and a cake in one transaction" => sub {
             },
           }
       }) ],
-      [ 'Cake/set'       => superhashof({}) ],
+      [ 'Cake/set'       => superhashof({
+          created => {
+            magic => superhashof({
+              id => ignore (),
+            }),
+          },
+      }) ],
     ],
     "we can bake cakes with recipes in one go",
   ) or note(explain($res->as_pairs));
@@ -768,8 +774,6 @@ subtest "delete the deleted" => sub {
 };
 
 subtest "duplicated creation ids" => sub {
-  # TODO -- michael, 2018-05-09
-  local $TODO = 'revisit with bakrefs';
   my $res = $jmap_tester->request([
     [
       'CakeRecipe/set' => { create => {

--- a/t/basic.t
+++ b/t/basic.t
@@ -90,7 +90,7 @@ $jmap_tester->_set_cookie('bakesaleUserId', $account{users}{rjbs});
 
 {
   my $res = $jmap_tester->request([
-    [ getCookies => {
+    [ 'Cookie/get' => {
         ids   => [ 1 ],
         tasty => 1,
         kakes => \1,
@@ -108,13 +108,13 @@ $jmap_tester->_set_cookie('bakesaleUserId', $account{users}{rjbs});
         },
       ],
     ],
-    "you can't just pass random new args to getFoos",
+    "you can't just pass random new args to Foo/get",
   );
 }
 
 {
   my $res = $jmap_tester->request([
-    [ getCookieUpdates => {
+    [ 'Cookie/changes' => {
         sinceState   => 2,
         fetchRecords => \1,
         fetchRecordProperties => [ qw(type) ],
@@ -131,9 +131,9 @@ $jmap_tester->_set_cookie('bakesaleUserId', $account{users}{rjbs});
   cmp_deeply(
     $jmap_tester->strip_json_types( $res->as_pairs ),
     [
-      [ cookieUpdates => ignore() ],
+      [ 'Cookie/changes' => ignore() ],
       [
-        cookies => {
+        'Cookie/get' => {
           notFound => undef,
           state => 8,
           list  => [
@@ -144,7 +144,7 @@ $jmap_tester->_set_cookie('bakesaleUserId', $account{users}{rjbs});
         },
       ],
     ],
-    "a getFoos call backed by the database",
+    "a Foo/get call backed by the database",
   );
 }
 
@@ -154,7 +154,7 @@ $jmap_tester->_set_cookie('bakesaleUserId', $account{users}{rjbs});
 
   my $res = $jmap_tester->request([
     [
-      getCookies => {
+      'Cookie/get' => {
         ids        => [ $account{cookies}{4}, $does_not_exist ],
         properties => [ qw(type) ]
       }
@@ -171,7 +171,7 @@ $jmap_tester->_set_cookie('bakesaleUserId', $account{users}{rjbs});
     $jmap_tester->strip_json_types( $res->as_pairs ),
     [
       [
-        cookies => {
+        'Cookie/get' => {
           notFound => [ $does_not_exist ],
           state => 8,
           list  => [
@@ -180,13 +180,13 @@ $jmap_tester->_set_cookie('bakesaleUserId', $account{users}{rjbs});
         },
       ],
     ],
-    "a getFoos call with notFound entries",
+    "a Foo/get call with notFound entries",
   );
 }
 
 {
   my $res = $jmap_tester->request([
-    [ getCakes => { } ],
+    [ 'Cake/get' => { } ],
   ]);
 
   cmp_deeply(
@@ -199,13 +199,13 @@ $jmap_tester->_set_cookie('bakesaleUserId', $account{users}{rjbs});
         }
       ]
     ],
-    "a getCakes call without 'ids' argument",
+    "a Cake/get call without 'ids' argument",
   );
 }
 
 {
   my $res = $jmap_tester->request([
-    [ setCookies => { ifInState => 3, destroy => [ 4 ] } ],
+    [ 'Cookie/set' => { ifInState => 3, destroy => [ 4 ] } ],
   ]);
 
   cmp_deeply(
@@ -213,7 +213,7 @@ $jmap_tester->_set_cookie('bakesaleUserId', $account{users}{rjbs});
     [
       [ error => { type => 'stateMismatch' } ],
     ],
-    "setCookies respects ifInState",
+    "Cookie/set respects ifInState",
   );
 }
 
@@ -222,7 +222,7 @@ my @created_ids;
 {
   my $res = $jmap_tester->request([
     [
-      setCookies => {
+      'Cookie/set' => {
         ifInState => 8,
         create    => {
           yellow => { type => 'shortbread', baked_at => undef },
@@ -243,7 +243,7 @@ my @created_ids;
     $jmap_tester->strip_json_types( $res->as_pairs ),
     [
       [
-        cookiesSet => superhashof({
+        'Cookie/set' => superhashof({
           oldState => 8,
           newState => 9,
 
@@ -279,7 +279,7 @@ my @created_ids;
         }),
       ],
     ],
-    "we can create cookies with setCookies",
+    "we can create cookies with Cookie/set",
   ) or diag(explain($jmap_tester->strip_json_types( $res->as_pairs )));
 
   my $set = $res->single_sentence->as_set;
@@ -300,7 +300,7 @@ my @created_ids;
   # Check ix_update_check
   $res = $jmap_tester->request([
     [
-      setCookies => {
+      'Cookie/set' => {
         ifInState => 9,
         update => {
           $account{cookies}{1} => { type => 'tim-tam' },
@@ -314,7 +314,7 @@ my @created_ids;
     $jmap_tester->strip_json_types( $res->as_pairs ),
     [
       [
-        cookiesSet => superhashof({
+        'Cookie/set' => superhashof({
           notUpdated => {
             $account{cookies}{1} => superhashof({
               'type' => 'partyFoul',
@@ -334,14 +334,14 @@ my @created_ids;
 
 {
   my $res = $jmap_tester->request([
-    [ getCookieUpdates => { sinceState => 8 } ],
+    [ 'Cookie/changes' => { sinceState => 8 } ],
   ]);
 
   cmp_deeply(
     $jmap_tester->strip_json_types( $res->as_pairs ),
     [
       [
-        cookieUpdates => {
+        'Cookie/changes' => {
           oldState => 8,
           newState => 9,
           hasMoreUpdates => bool(0),
@@ -357,7 +357,7 @@ my @created_ids;
 subtest "invalid sinceState" => sub {
   subtest "too high" => sub {
     my $res = $jmap_tester->request([
-      [ getCookieUpdates => { sinceState => 999 } ],
+      [ 'Cookie/changes' => { sinceState => 999 } ],
     ]);
 
     cmp_deeply(
@@ -369,7 +369,7 @@ subtest "invalid sinceState" => sub {
 
   subtest "too low" => sub {
     my $res = $jmap_tester->request([
-      [ getCookieUpdates => { sinceState => -1 } ],
+      [ 'Cookie/changes' => { sinceState => -1 } ],
     ]);
 
     cmp_deeply(
@@ -382,11 +382,11 @@ subtest "invalid sinceState" => sub {
 
 {
   my $get_res = $jmap_tester->request([
-    [ getCookies => { ids => [ $account{cookies}{1}, @created_ids ] } ],
+    [ 'Cookie/get' => { ids => [ $account{cookies}{1}, @created_ids ] } ],
   ]);
 
   my $res = $jmap_tester->request([
-    [ getCookieUpdates => { sinceState => 8, fetchRecords => 1 } ],
+    [ 'Cookie/changes' => { sinceState => 8, fetchRecords => 1 } ],
   ]);
 
   my $get_payloads = $jmap_tester->strip_json_types(
@@ -397,7 +397,7 @@ subtest "invalid sinceState" => sub {
     $jmap_tester->strip_json_types( $res->as_pairs ),
     [
       [
-        cookieUpdates => {
+        'Cookie/changes' => {
           oldState => 8,
           newState => 9,
           hasMoreUpdates => bool(0),
@@ -406,7 +406,7 @@ subtest "invalid sinceState" => sub {
         },
       ],
       [
-        cookies => {
+        'Cookie/get' => {
           $get_payloads->%*,
           list => bag( $get_payloads->{list}->@* ),
         },
@@ -419,7 +419,7 @@ subtest "invalid sinceState" => sub {
 {
   my $res = $jmap_tester->request([
     [
-      setCakes => {
+      'Cake/set' => {
         ifInState => '0-0',
         create    => {
           yum => { type => 'layered', layer_count => 4, recipeId => $account{recipes}{1} },
@@ -433,7 +433,7 @@ subtest "invalid sinceState" => sub {
     $jmap_tester->strip_json_types( $res->as_pairs ),
     [
       [
-        cakesSet => superhashof({
+        'Cake/set' => superhashof({
           created => {
             yum => superhashof({ baked_at => ignore() }),
           },
@@ -453,7 +453,7 @@ subtest "invalid sinceState" => sub {
 subtest "passing in a boolean" => sub {
   my $res = $jmap_tester->request([
     [
-      setCakeRecipes => {
+      'CakeRecipe/set' => {
         create => {
           boat => {
             type          => 'cake boat',
@@ -469,7 +469,7 @@ subtest "passing in a boolean" => sub {
     $jmap_tester->strip_json_types( $res->as_pairs ),
     [
       [
-        cakeRecipesSet => superhashof({
+        'CakeRecipe/set' => superhashof({
           created => {
             boat => { id => ignore(), sku => re(qr/\A[0-9]{5}\z/), },
           }
@@ -482,14 +482,14 @@ subtest "passing in a boolean" => sub {
   my $id = $res->single_sentence->as_set->created_id('boat');
 
   my $get = $jmap_tester->request([
-    [ getCakeRecipes => { ids => [ "$id" ] } ]
+    [ 'CakeRecipe/get' => { ids => [ "$id" ] } ]
   ]);
 
   cmp_deeply(
     $jmap_tester->strip_json_types( $get->as_pairs ),
     [
       [
-        cakeRecipes => superhashof({
+        'CakeRecipe/get' => superhashof({
           list => [ superhashof({ id => "$id", is_delicious => bool(0) }) ],
         }),
       ],
@@ -500,7 +500,7 @@ subtest "passing in a boolean" => sub {
   # Can't use something that looks like a boolean
   $res = $jmap_tester->request([
     [
-      setCakeRecipes => {
+      'CakeRecipe/set' => {
         create => {
           boat => {
             type          => 'cake boat',
@@ -513,7 +513,7 @@ subtest "passing in a boolean" => sub {
   ]);
 
   my $err = $res->paragraph(0)
-                ->single('cakeRecipesSet')
+                ->single('CakeRecipe/set')
                 ->as_set
                 ->create_errors;
 
@@ -534,14 +534,14 @@ subtest "passing in a boolean" => sub {
 subtest "make a recipe and a cake in one transaction" => sub {
   my $res = $jmap_tester->request([
     [
-      setCakeRecipes => {
+      'CakeRecipe/set' => {
         create => {
           pav => { type => 'pavlova', avg_review => 50 }
         },
       },
     ],
     [
-      setCakes => {
+      'Cake/set' => {
         create    => {
           magic => { type => 'eggy', layer_count => 2, recipeId => '#pav' },
         }
@@ -552,7 +552,7 @@ subtest "make a recipe and a cake in one transaction" => sub {
   cmp_deeply(
     $jmap_tester->strip_json_types( $res->as_pairs ),
     [
-      [ cakeRecipesSet => superhashof({
+      [ 'CakeRecipe/set' => superhashof({
           created => {
             pav => {
               id => ignore(),
@@ -561,7 +561,7 @@ subtest "make a recipe and a cake in one transaction" => sub {
             },
           }
       }) ],
-      [ cakesSet       => superhashof({}) ],
+      [ 'Cake/set'       => superhashof({}) ],
     ],
     "we can bake cakes with recipes in one go",
   ) or note(explain($res->as_pairs));
@@ -573,13 +573,13 @@ subtest "subroutine defaults for lazy computation" => sub {
   {
     my $res = $jmap_tester->request([
       [
-        setCakeRecipes => {
+        'CakeRecipe/set' => {
           create => { pac => { type => 'pat-a-cake', avg_review => 81 } },
         },
       ],
     ]);
 
-    my $sku = $res->single_sentence('cakeRecipesSet')
+    my $sku = $res->single_sentence('CakeRecipe/set')
                   ->as_set
                   ->created->{pac}{sku};
 
@@ -594,7 +594,7 @@ subtest "subroutine defaults for lazy computation" => sub {
   {
     my $res = $jmap_tester->request([
       [
-        setCakeRecipes => {
+        'CakeRecipe/set' => {
           create => {
             bug => { type => 'insect', avg_review => 8, sku => 'BUG001' }
           },
@@ -602,7 +602,7 @@ subtest "subroutine defaults for lazy computation" => sub {
       ],
     ]);
 
-    my $bug = $res->single_sentence('cakeRecipesSet')->as_set->created->{bug};
+    my $bug = $res->single_sentence('CakeRecipe/set')->as_set->created->{bug};
     ok( ! exists $bug->{sku}, "non-default sku, so not returned in set");
 
     is(
@@ -612,10 +612,10 @@ subtest "subroutine defaults for lazy computation" => sub {
     );
 
     my $bug_get_res = $jmap_tester->request([
-      [ getCakeRecipes => { ids => [ $bug->{id} ] } ]
+      [ 'CakeRecipe/get' => { ids => [ $bug->{id} ] } ]
     ]);
 
-    my $bug_get = $bug_get_res->single_sentence('cakeRecipes')
+    my $bug_get = $bug_get_res->single_sentence('CakeRecipe/get')
                               ->arguments
                               ->{list}[0];
 
@@ -626,7 +626,7 @@ subtest "subroutine defaults for lazy computation" => sub {
 {
   my $res = $jmap_tester->request([
     [
-      setCookies => {
+      'Cookie/set' => {
         ifInState => 9,
         destroy   => [ 3 ],
         create    => { blue => {} },
@@ -639,7 +639,7 @@ subtest "subroutine defaults for lazy computation" => sub {
     $jmap_tester->strip_json_types( $res->as_pairs ),
     [
       [
-        cookiesSet => superhashof({
+        'Cookie/set' => superhashof({
           oldState => 9,
           newState => 9,
 
@@ -656,7 +656,7 @@ subtest "subroutine defaults for lazy computation" => sub {
 {
   my $res = $jmap_tester->request([
     [
-      setCookies => {
+      'Cookie/set' => {
         create => { raw => { type => 'dough', baked_at => undef } },
       },
     ],
@@ -666,7 +666,7 @@ subtest "subroutine defaults for lazy computation" => sub {
     $jmap_tester->strip_json_types( $res->as_pairs ),
     [
       [
-        cookiesSet => superhashof({
+        'Cookie/set' => superhashof({
           created => { raw => { id => re(qr/\S/), expires_at => ignore(), delicious => ignore(), external_id => ignore(), batch => ignore(), } },
         }),
       ],
@@ -677,8 +677,8 @@ subtest "subroutine defaults for lazy computation" => sub {
 
 {
   my $res = $jmap_tester->request([
-    [ setCookies => { create => { oatmeal => { type => 'oatmeal' } } } ],
-    [ setCookies => { create => { mealoat => { type => 'oatmeal' } } } ],
+    [ 'Cookie/set' => { create => { oatmeal => { type => 'oatmeal' } } } ],
+    [ 'Cookie/set' => { create => { mealoat => { type => 'oatmeal' } } } ],
   ]);
 
   my %state;
@@ -689,13 +689,13 @@ subtest "subroutine defaults for lazy computation" => sub {
     $jmap_tester->strip_json_types( $res->as_pairs ),
     [
       [
-        cookiesSet => superhashof({
+        'Cookie/set' => superhashof({
           oldState => code(sub { $state{old} = $_[0]; 1 } ),
           newState => code(sub { $state{ s1} = $_[0]; 1 } ),
         }),
       ],
       [
-        cookiesSet => superhashof({
+        'Cookie/set' => superhashof({
           oldState => code(sub { $state{ s1} eq $_[0] }),
           newState => code(sub { $state{ s2} = $_[0]; 1 } ),
         }),
@@ -709,26 +709,26 @@ subtest "subroutine defaults for lazy computation" => sub {
 
 subtest "no-update update" => sub {
   my $res1 = $jmap_tester->request([
-    [ setCookies => { create => { twisty => { type => 'oreo' } } } ],
+    [ 'Cookie/set' => { create => { twisty => { type => 'oreo' } } } ],
   ]);
 
-  my $set1 = $res1->single_sentence('cookiesSet')->as_set;
+  my $set1 = $res1->single_sentence('Cookie/set')->as_set;
   my $id = $set1->created_id('twisty');
 
   my $res2 = $jmap_tester->request([
-    [ setCookies => { update => { "$id" => { type => 'hydrox' } } } ],
+    [ 'Cookie/set' => { update => { "$id" => { type => 'hydrox' } } } ],
   ]);
 
-  my $set2 = $res2->single_sentence('cookiesSet')->as_set;
+  my $set2 = $res2->single_sentence('Cookie/set')->as_set;
 
   is(  $set2->old_state, $set1->new_state, "1st update starts at create state");
   isnt($set2->new_state, $set1->new_state, "1st update ends at new state");
 
   my $res3 = $jmap_tester->request([
-    [ setCookies => { update => { "$id" => { type => 'hydrox' } } } ],
+    [ 'Cookie/set' => { update => { "$id" => { type => 'hydrox' } } } ],
   ]);
 
-  my $set3 = $res3->single_sentence('cookiesSet')->as_set;
+  my $set3 = $res3->single_sentence('Cookie/set')->as_set;
 
   is(  $set3->old_state, $set2->new_state, "2nd update starts at 1st update");
   is(  $set3->new_state, $set2->new_state, "2nd update does not change state");
@@ -736,52 +736,54 @@ subtest "no-update update" => sub {
 
 subtest "delete the deleted" => sub {
   my $res1 = $jmap_tester->request([
-    [ setCookies => { create => { doomed => { type => 'pistachio' } } } ],
+    [ 'Cookie/set' => { create => { doomed => { type => 'pistachio' } } } ],
   ]);
 
-  my $set1 = $res1->single_sentence('cookiesSet')->as_set;
+  my $set1 = $res1->single_sentence('Cookie/set')->as_set;
   my $id = $set1->created_id('doomed');
 
   my $res2 = $jmap_tester->request([
-    [ setCookies => { destroy => [ "$id" ] } ],
+    [ 'Cookie/set' => { destroy => [ "$id" ] } ],
   ]);
 
-  my $set2 = $res2->single_sentence('cookiesSet')->as_set;
+  my $set2 = $res2->single_sentence('Cookie/set')->as_set;
 
   is_deeply([ $set2->destroyed_ids ], [ $id ], "we destroy the item");
 
   my $res3 = $jmap_tester->request([
-    [ setCookies => { destroy => [ "$id" ] } ],
+    [ 'Cookie/set' => { destroy => [ "$id" ] } ],
   ]);
 
-  my $set3 = $res3->single_sentence('cookiesSet')->as_set;
+  my $set3 = $res3->single_sentence('Cookie/set')->as_set;
 
   is_deeply([ $set3->destroyed_ids ], [ ], "we destroy nothing");
   is_deeply([ $set3->not_destroyed_ids ], [ $id ], "...especially not $id");
 };
 
 subtest "duplicated creation ids" => sub {
+  # TODO -- michael, 2018-05-09
+  local $TODO = 'revisit with bakrefs';
   my $res = $jmap_tester->request([
     [
-      setCakeRecipes => { create => {
+      'CakeRecipe/set' => { create => {
         yummy => { type => 'yummykake', avg_review => 80 },
         tasty => { type => 'tastykake', avg_review => 80 },
       } }
     ],
     [
-      setCakes => { create    => {
+      'Cake/set' => { create    => {
         yc1   => { type => 'y1', layer_count => 1, recipeId => '#yummy' },
         tc    => { type => 't1', layer_count => 2, recipeId => '#tasty' },
       } },
     ],
     [
-      setCakeRecipes => { create => {
+      'CakeRecipe/set' => { create => {
         yummy => { type => 'raspberry', avg_review => 82 },
         gross => { type => 'slugflour', avg_review => 12 },
       } }
     ],
     [
-      setCakes => { create    => {
+      'Cake/set' => { create    => {
         yc2  => { type => 'y2', layer_count => 3, recipeId => '#yummy' },
         gc   => { type => 'g1', layer_count => 4, recipeId => '#gross' },
       } },
@@ -792,7 +794,7 @@ subtest "duplicated creation ids" => sub {
     $jmap_tester->strip_json_types( $res->as_pairs ),
     [
       [
-        cakeRecipesSet => superhashof({
+        'CakeRecipe/set' => superhashof({
           notCreated => {},
           created => {
             yummy => superhashof({}),
@@ -801,18 +803,18 @@ subtest "duplicated creation ids" => sub {
         })
       ],
       [
-        cakesSet       => superhashof({
+        'Cake/set'       => superhashof({
           notCreated => {},
           created => { yc1 => superhashof({}), tc => superhashof({}) },
         })
       ],
       [
-        cakeRecipesSet => superhashof({
+        'CakeRecipe/set' => superhashof({
           created => { gross => superhashof({}), yummy => superhashof({}) },
         }),
       ],
       [
-        cakesSet       => superhashof({
+        'Cake/set'       => superhashof({
           notCreated => { yc2 => superhashof({ type => 'duplicateCreationId' }) },
           created => { gc => superhashof({}) },
         }),
@@ -829,7 +831,7 @@ subtest "timestamptz field validations" => sub {
 
   my $res = $jmap_tester->request([
     [
-      setCookies => {
+      'Cookie/set' => {
         create    => {
           yellow => { type => 'yellow' }, # default baked_at
           gold   => { type => 'gold', baked_at => undef }, # null baked_at
@@ -851,7 +853,7 @@ subtest "timestamptz field validations" => sub {
     $jmap_tester->strip_json_types( $res->as_pairs ),
     [
       [
-        cookiesSet => superhashof({
+        'Cookie/set' => superhashof({
           oldState => ignore(),
           newState => code(sub { $state = $_[0]; 1}),
           created => {
@@ -885,7 +887,7 @@ subtest "timestamptz field validations" => sub {
   # Verify
   $res = $jmap_tester->request([
     [
-      getCookieUpdates => {
+      'Cookie/changes' => {
         sinceState => $state - 1,
         fetchRecords => \1,
         fetchRecordProperties => [ qw(type baked_at expires_at) ],
@@ -898,9 +900,9 @@ subtest "timestamptz field validations" => sub {
   cmp_deeply(
     $data,
     [
-      [ cookieUpdates => ignore() ],
+      [ 'Cookie/changes' => ignore() ],
       [
-        cookies => {
+        'Cookie/get' => {
           notFound => undef,
           state => $state,
           list  => bag(
@@ -923,7 +925,7 @@ subtest "timestamptz field validations" => sub {
 
   $res = $jmap_tester->request([
     [
-      setCookies => {
+      'Cookie/set' => {
         update => {
           $c_to_id{yellow} => { type => 'tim tam' }, # Leave baked_at
           $c_to_id{gold}   => { baked_at => '2016-01-01T12:34:56Z' },
@@ -940,7 +942,7 @@ subtest "timestamptz field validations" => sub {
     $jmap_tester->strip_json_types( $res->as_pairs ),
     [
       [
-        cookiesSet => superhashof({
+        'Cookie/set' => superhashof({
           oldState => $state,
           newState => $state + 1,
           updated => {
@@ -970,7 +972,7 @@ subtest "timestamptz field validations" => sub {
   # Verify (still using much older state so we can see white in the list)
   $res = $jmap_tester->request([
     [
-      getCookieUpdates => {
+      'Cookie/changes' => {
         sinceState => $state - 2,
         fetchRecords => \1,
         fetchRecordProperties => [ qw(type baked_at expires_at) ],
@@ -983,9 +985,9 @@ subtest "timestamptz field validations" => sub {
   cmp_deeply(
     $data,
     [
-      [ cookieUpdates => ignore() ],
+      [ 'Cookie/changes' => ignore() ],
       [
-        cookies => {
+        'Cookie/get' => {
           notFound => undef,
           state => $state,
           list  => set(
@@ -1006,7 +1008,7 @@ subtest "timestamptz field validations" => sub {
 subtest "db exceptions" => sub {
   # Make sure ix_create_error/update_error/destroy_error fire and work
   my $res = $jmap_tester->request([
-    [ setUsers => {
+    [ 'User/set' => {
       create => {
         first       => { username => 'first', },
         second      => { username => 'second', },
@@ -1015,7 +1017,7 @@ subtest "db exceptions" => sub {
     } ],
   ]);
 
-  my $created = $res->paragraph(0)->single('usersSet')->as_set;
+  my $created = $res->paragraph(0)->single('User/set')->as_set;
   my $first_id = $created->created_id('first');
   my $second_id = $created->created_id('second');
   my $nobody_id = $created->created_id('nobody');
@@ -1026,7 +1028,7 @@ subtest "db exceptions" => sub {
 
   # Now try to create duplicate user first
   $res = $jmap_tester->request([
-    [ setUsers => {
+    [ 'User/set' => {
       create => {
         first       => { username => 'first', },
       },
@@ -1034,7 +1036,7 @@ subtest "db exceptions" => sub {
   ]);
 
   my $err = $res->paragraph(0)
-                ->single('usersSet')
+                ->single('User/set')
                 ->as_set
                 ->create_errors;
 
@@ -1052,7 +1054,7 @@ subtest "db exceptions" => sub {
   # But we can 'create' duplicate 'nobody' users (it just returns the
   # the existing one
   $res = $jmap_tester->request([
-    [ setUsers => {
+    [ 'User/set' => {
       create => {
         first => { username => 'nobody', status => 'whatever' },
       },
@@ -1060,7 +1062,7 @@ subtest "db exceptions" => sub {
   ]);
 
   jcmp_deeply(
-    $res->paragraph(0)->single('usersSet')->as_set->created,
+    $res->paragraph(0)->single('User/set')->as_set->created,
     {
       first => {
         id       => $nobody_id,
@@ -1072,7 +1074,7 @@ subtest "db exceptions" => sub {
 
   # Try with update
   $res = $jmap_tester->request([
-    [ setUsers => {
+    [ 'User/set' => {
       update => {
         $first_id => { username => 'second', },
       },
@@ -1080,7 +1082,7 @@ subtest "db exceptions" => sub {
   ]);
 
   $err = $res->paragraph(0)
-                ->single('usersSet')
+                ->single('User/set')
                 ->as_set
                 ->update_errors;
 
@@ -1102,7 +1104,7 @@ subtest "db exceptions" => sub {
 
   # First, get state
   $res = $jmap_tester->request([
-    [ getUsers => { ids => [ $first_id ] }, ],
+    [ 'User/get' => { ids => [ $first_id ] }, ],
   ]);
 
   ok(my $state = $res->single_sentence->arguments->{state}, "got state")
@@ -1110,7 +1112,7 @@ subtest "db exceptions" => sub {
 
   # Now attempt to change first user to 'nobody'
   $res = $jmap_tester->request([
-    [ setUsers => {
+    [ 'User/set' => {
       update => {
         $first_id => { username => 'nobody', },
       },
@@ -1132,7 +1134,7 @@ subtest "db exceptions" => sub {
   # Make sure ix_set_check works
   my $res = $jmap_tester->request([
     [
-      setCookies => {
+      'Cookie/set' => {
         create => {
           actually_a_cake => { type => 'cake' },
         },
@@ -1159,7 +1161,7 @@ subtest "supplied created values changed" => sub {
   # scenes during create, we need to supply the new value to the user
   # so that their data is in sync with ours
   my $res = $jmap_tester->request([
-    [ setUsers => {
+    [ 'User/set' => {
       create => {
         # status will remain active, we should not get status back
         active       => { username => 'active', status => 'active' },
@@ -1171,7 +1173,7 @@ subtest "supplied created values changed" => sub {
   ]);
 
   my $created = $jmap_tester->strip_json_types(
-    $res->paragraph(0)->single('usersSet')->as_set->created
+    $res->paragraph(0)->single('User/set')->as_set->created
   );
 
   cmp_deeply(
@@ -1189,7 +1191,7 @@ subtest "various string id tests" => sub {
   # are integers only. Make sure junk string ids don't throw database
   # exceptions
   my $res = $jmap_tester->request([
-    [ setCakes => {
+    [ 'Cake/set' => {
       create => {
         "new" => { type => 'layered', layer_count => 4, recipeId => "cat", },
       },
@@ -1199,10 +1201,10 @@ subtest "various string id tests" => sub {
       destroy => [ 'to_destroy' ],
     }, 'a', ],
     [
-      getCakes => { ids => [ 'bad' ] }, 'b',
+      'Cake/get' => { ids => [ 'bad' ] }, 'b',
     ],
     [
-      getCookieUpdates => { sinceState => 'bad' }, 'c',
+      'Cookie/changes' => { sinceState => 'bad' }, 'c',
     ],
   ]);
 
@@ -1210,7 +1212,7 @@ subtest "various string id tests" => sub {
     $res->as_stripped_triples,
     [
       [
-        'cakesSet',
+        'Cake/set',
         {
           'created' => {},
           'destroyed' => [],
@@ -1242,7 +1244,7 @@ subtest "various string id tests" => sub {
         'a',
       ],
       [
-        'cakes',
+        'Cake/get',
         {
           'list' => [],
           'notFound' => [
@@ -1269,7 +1271,7 @@ subtest "virtual properties in create" => sub {
   # If a class has virtual properties, they should come back in
   # the create call. For now this is up to subclasses to manage
   my $res = $jmap_tester->request([
-    [ setUsers => {
+    [ 'User/set' => {
       create => {
         virtualprops => { username => 'virtualprops', status => 'active' },
       },
@@ -1277,7 +1279,7 @@ subtest "virtual properties in create" => sub {
   ]);
 
   my $created = $jmap_tester->strip_json_types(
-    $res->paragraph(0)->single('usersSet')->as_set->created
+    $res->paragraph(0)->single('User/set')->as_set->created
   );
 
   cmp_deeply(
@@ -1290,55 +1292,55 @@ subtest "virtual properties in create" => sub {
 
   # Also comes back in gets
   $res = $jmap_tester->request([
-    [ getUsers => { ids => [ $created->{virtualprops}->{id} ] } ],
+    [ 'User/get' => { ids => [ $created->{virtualprops}->{id} ] } ],
   ]);
 
   my $got = $jmap_tester->strip_json_types(
-    $res->paragraph(0)->single('users')->as_set->arguments->{list}->[0]
+    $res->paragraph(0)->single('User/get')->as_set->arguments->{list}->[0]
   );
 
   cmp_deeply(
     $got,
     superhashof({ ranking => 7 }),
-    "got ranking back from getUsers"
+    "got ranking back from User/get"
   );
 };
 
 subtest "destroyed rows don't interfere with unique constraints" => sub {
   # Make sure destroyed rows don't interfere with unique constraints
   my $res = $jmap_tester->request([
-    [ setUsers => {
+    [ 'User/set' => {
       create => {
         first => { username => 'a new user', },
       },
     } ],
   ]);
 
-  my $id = $res->paragraph(0)->single('usersSet')->as_set->created_id('first');
+  my $id = $res->paragraph(0)->single('User/set')->as_set->created_id('first');
   ok($id, 'created a user');
 
   # Destroy that user
   $res = $jmap_tester->request([
-     [ setUsers => {
+     [ 'User/set' => {
        destroy => [ $id ],
      } ],
   ]);
   is(
-    ($res->single_sentence('usersSet')->as_set->destroyed_ids)[0],
+    ($res->single_sentence('User/set')->as_set->destroyed_ids)[0],
     $id,
     'user destroyed'
   );
 
   # Now create a new user with same username
   $res = $jmap_tester->request([
-    [ setUsers => {
+    [ 'User/set' => {
       create => {
         first => { username => 'a new user', },
       },
     } ],
   ]);
 
-  my $id2 = $res->paragraph(0)->single('usersSet')->as_set->created_id('first');
+  my $id2 = $res->paragraph(0)->single('User/set')->as_set->created_id('first');
   ok($id2, 'created a user with same username as destroyed user')
     or diag explain $res->as_stripped_triples;
 
@@ -1382,7 +1384,7 @@ subtest "non-ASCII data" => sub {
 
     my $res = $jmap_tester->request([
       [
-        setCakeRecipes => {
+        'CakeRecipe/set' => {
           create => {
             yum  => {
               type          => $shoefly,
@@ -1405,8 +1407,8 @@ subtest "non-ASCII data" => sub {
       my $id  = $set->created_id('taro');
       pass("created taro cake! id: $id");
       ok(! exists $set->created->{taro}{type}, "type used unaltered");
-      my $cake = $jmap_tester->request([[ getCakeRecipes => { ids => [ $id ] } ]]);
-      my $type = $cake->single_sentence('cakeRecipes')->arguments->{list}[0]{type};
+      my $cake = $jmap_tester->request([[ 'CakeRecipe/get' => { ids => [ $id ] } ]]);
+      my $type = $cake->single_sentence('CakeRecipe/get')->arguments->{list}[0]{type};
       is($type, $taro_cake, "type round tripped");
     };
 
@@ -1415,8 +1417,8 @@ subtest "non-ASCII data" => sub {
       pass("created shoefly cake (really it's pie)! id: $id");
       is($set->created->{yum}{type}, NFC($shoefly), "informed of str normalization");
 
-      my $cake = $jmap_tester->request([[ getCakeRecipes => { ids => [ $id ] } ]]);
-      my $type = $cake->single_sentence('cakeRecipes')->arguments->{list}[0]{type};
+      my $cake = $jmap_tester->request([[ 'CakeRecipe/get' => { ids => [ $id ] } ]]);
+      my $type = $cake->single_sentence('CakeRecipe/get')->arguments->{list}[0]{type};
       isnt($type, $shoefly,       "type didn't round trip unaltered...");
       is($type,   NFC($shoefly),  "...because it got NFC'd");
     };
@@ -1430,14 +1432,14 @@ subtest "ix_created test" => sub {
   # Get topper state
   my $res = $jmap_tester->request([
     [
-      getCakeToppers => { ids => [] }
+      'CakeTopper/get' => { ids => [] }
     ],
   ]);
   ok(defined(my $state = $res->sentence(0)->arguments->{state}), 'got state');
 
   $res = $jmap_tester->request([
     [
-      setCakes => {
+      'Cake/set' => {
         create => {
           yum => { type => 'wedding', layer_count => 4, recipeId => $account{recipes}{1} },
           woo => { type => 'wedding', layer_count => 8, recipeId => $account{recipes}{1} },
@@ -1450,7 +1452,7 @@ subtest "ix_created test" => sub {
     $jmap_tester->strip_json_types( $res->as_stripped_triples ),
     [
       [
-        cakesSet => superhashof({
+        'Cake/set' => superhashof({
           created => {
             yum => superhashof({ id => ignore() }),
             woo => superhashof({ id => ignore() }),
@@ -1458,7 +1460,7 @@ subtest "ix_created test" => sub {
         }), "my id"
       ],
       [
-        cakeToppers => superhashof({
+        'CakeTopper/get' => superhashof({
           list => set(
             {
               cakeId => $res->as_stripped_triples->[0][1]{created}{yum}{id},
@@ -1493,7 +1495,7 @@ subtest "ix_created test" => sub {
   print STDERR "Ignore the next two exception reports for now..\n";
   $res = $jmap_tester->request([
     [
-      setCakes => {
+      'Cake/set' => {
         create => {
           yum => { type => 'wedding', layer_count => 4, recipeId => $account{recipes}{1} },
           woo => { type => 'wedding', layer_count => 8, recipeId => $account{recipes}{1} },
@@ -1506,7 +1508,7 @@ subtest "ix_created test" => sub {
     $res->as_stripped_triples,
     [
       [
-        cakesSet => superhashof({
+        'Cake/set' => superhashof({
           notCreated => {
             woo => { guid => ignore(), type => 'internalError' },
             yum => { guid => ignore(), type => 'internalError' },
@@ -1520,10 +1522,10 @@ subtest "ix_created test" => sub {
   is($res->http_response->header('Vary'), 'Origin', 'got Vary header');
   ok($res->http_response->header('Ix-Transaction-ID'), 'we have a request guid!');
 
-  $res = $jmap_tester->request([ [ getCakes => { ids => [ 1 ] } ] ]);
+  $res = $jmap_tester->request([ [ 'Cake/get' => { ids => [ 1 ] } ] ]);
   is("". $res->sentence(0)->arguments->{state}, $cstate, 'cake state unchanged');
 
-  $res = $jmap_tester->request([ [ getCakeToppers => {} ] ]);
+  $res = $jmap_tester->request([ [ 'CakeTopper/get' => {} ] ]);
   is("". $res->sentence(0)->arguments->{state}, $tstate, 'cake topper state unchanged');
 };
 
@@ -1532,7 +1534,7 @@ subtest "ix_created test" => sub {
 
   # Check state, should be 0
   my $res = $jmap_tester->request([
-    [ getCookies => {} ],
+    [ 'Cookie/get' => {} ],
   ]);
 
   is($res->single_sentence->arguments->{state}, 0, 'got state of 0')
@@ -1540,7 +1542,7 @@ subtest "ix_created test" => sub {
 
   # Ask for updates, should be told we are in sync
   $res = $jmap_tester->request([
-    [ getCookieUpdates => {
+    [ 'Cookie/changes' => {
         sinceState   => 0,
         fetchRecords => \1,
         fetchRecordProperties => [ qw(type) ],
@@ -1556,7 +1558,7 @@ subtest "ix_created test" => sub {
   # Add some cookies, ensure ifInState works
   $res = $jmap_tester->request([
     [
-      setCookies => {
+      'Cookie/set' => {
         ifInState => 0,
         create    => {
           yellow => { type => 'shortbread', },
@@ -1570,7 +1572,7 @@ subtest "ix_created test" => sub {
     $jmap_tester->strip_json_types( $res->as_pairs ),
     [
       [
-        cookiesSet => superhashof({
+        'Cookie/set' => superhashof({
           oldState => 0,
           newState => 1,
 
@@ -1589,18 +1591,18 @@ subtest "ix_created test" => sub {
 
   # Verify updates
   $res = $jmap_tester->request([
-    [ getCookieUpdates => { sinceState => '0' } ],
+    [ 'Cookie/changes' => { sinceState => '0' } ],
   ]);
 
   cmp_deeply(
     $res->as_stripped_triples->[0][1]{changed},
     set(map { "$_" } @created_ids),
-    "getCookieUpdates with state of 0 works"
+    "'Cookie/changes' with state of 0 works"
   );
 
   # If our sinceState is too low we should get a resync
   $res = $jmap_tester->request([
-    [ getCookieUpdates => {
+    [ 'Cookie/changes' => {
         sinceState   => -1,
         fetchRecords => \1,
         fetchRecordProperties => [ qw(type) ],
@@ -1619,7 +1621,7 @@ subtest "ix_created test" => sub {
 
   # Complex ones too
   $res = $jmap_tester->request([
-    [ getCakeUpdates => { sinceState => '0-0' }, ],
+    [ 'Cake/changes' => { sinceState => '0-0' }, ],
   ]);
 
   $args = $res->single_sentence->arguments;
@@ -1645,17 +1647,17 @@ subtest "deleted entites in get*Updates calls" => sub {
 
   # Get current state
   my $res = $jmap_tester->request([
-    [ getCookies => {} ],
+    [ 'Cookie/get' => {} ],
   ]);
   my $start = $res->single_sentence->arguments->{state};
   ok($start, 'got starting cookie state');
 
   # Create a cookie
   $res = $jmap_tester->request([
-    [ setCookies => { create => { doomed => { type => 'pistachio' } } } ],
+    [ 'Cookie/set' => { create => { doomed => { type => 'pistachio' } } } ],
   ]);
 
-  my $id = $res->single_sentence('cookiesSet')->as_set->created_id('doomed');
+  my $id = $res->single_sentence('Cookie/set')->as_set->created_id('doomed');
   ok($id, 'created a doomed cookie');
 
   my $create = $res->single_sentence->arguments->{newState};
@@ -1663,11 +1665,11 @@ subtest "deleted entites in get*Updates calls" => sub {
 
   # Update it
   $res = $jmap_tester->request([
-    [ setCookies => { update => { $id => { type => 'almond' } } } ],
+    [ 'Cookie/set' => { update => { $id => { type => 'almond' } } } ],
   ]);
 
   is_deeply(
-    [ $res->single_sentence('cookiesSet')->as_set->updated_ids ],
+    [ $res->single_sentence('Cookie/set')->as_set->updated_ids ],
     [ $id ],
     "cookie was updated"
   );
@@ -1677,11 +1679,11 @@ subtest "deleted entites in get*Updates calls" => sub {
 
   # Destroy it with lazers
   $res = $jmap_tester->request([
-    [ setCookies => { destroy => [ "$id" ] } ],
+    [ 'Cookie/set' => { destroy => [ "$id" ] } ],
   ]);
 
   is_deeply(
-    [ $res->single_sentence('cookiesSet')->as_set->destroyed_ids ],
+    [ $res->single_sentence('Cookie/set')->as_set->destroyed_ids ],
     [ $id ],
     "cookie was destroyed"
   );
@@ -1703,7 +1705,7 @@ subtest "deleted entites in get*Updates calls" => sub {
     my ($state, $expect, $desc) = @$test;
 
     my $res = $jmap_tester->request([
-      [ getCookieUpdates => { sinceState => $state } ],
+      [ 'Cookie/changes' => { sinceState => $state } ],
     ]);
 
     jcmp_deeply(
@@ -1740,7 +1742,7 @@ subtest "good call gets headers" => sub {
   $jmap_tester->ua->default_header('Origin' => 'example.net');
 
   my $res = $jmap_tester->request([
-    [ getCookies => {} ],
+    [ 'Cookie/get' => {} ],
   ]);
 
   ok($res->sentence(0)->arguments->{list}, 'got a good response');
@@ -1754,17 +1756,17 @@ subtest "good call gets headers" => sub {
 
 subtest "dateDestroyed has timezone" => sub {
   my $res1 = $jmap_tester->request([
-    [ setCookies => { create => { doomed => { type => 'pistachio' } } } ],
+    [ 'Cookie/set' => { create => { doomed => { type => 'pistachio' } } } ],
   ]);
 
-  my $set1 = $res1->single_sentence('cookiesSet')->as_set;
+  my $set1 = $res1->single_sentence('Cookie/set')->as_set;
   my $id = $set1->created_id('doomed');
 
   my $res2 = $jmap_tester->request([
-    [ setCookies => { destroy => [ "$id" ] } ],
+    [ 'Cookie/set' => { destroy => [ "$id" ] } ],
   ]);
 
-  my $set2 = $res2->single_sentence('cookiesSet')->as_set;
+  my $set2 = $res2->single_sentence('Cookie/set')->as_set;
 
   is_deeply([ $set2->destroyed_ids ], [ $id ], "we destroy the item");
 
@@ -1790,7 +1792,7 @@ subtest "optional idstr" => sub {
   # Create a cookie with an external_id
   my $res = $jmap_tester->request([
     [
-      setCookies => {
+      'Cookie/set' => {
         create => { raw => { type => 'dough', baked_at => undef, external_id => ix_new_id() } },
       },
     ],
@@ -1808,7 +1810,7 @@ subtest "optional idstr" => sub {
 
   $res = $jmap_tester->request([
     [
-      setCookies => {
+      'Cookie/set' => {
         update => {
           $id => { external_id => undef },
         },
@@ -1825,7 +1827,7 @@ subtest "optional idstr" => sub {
 
 subtest "ix_custom_deployment_statements" => sub {
   my $res = $jmap_tester->request([
-    [ setUsers => {
+    [ 'User/set' => {
       create => {
         first       => { username => 'case', },
         second      => { username => 'CASE', },
@@ -1848,7 +1850,7 @@ subtest "ix_custom_deployment_statements" => sub {
 
 subtest "friendly duplicate key errors" => sub {
   my $create_res = $jmap_tester->request([
-    [ setUsers => {
+    [ 'User/set' => {
       create => {
         first  => { username => 'kaboom', },
         second => { username => 'anewuser2' },
@@ -1875,7 +1877,7 @@ subtest "friendly duplicate key errors" => sub {
 
   # Same with update
   my $update_res = $jmap_tester->request([
-    [ setUsers => {
+    [ 'User/set' => {
       update => {
         $second => { username => 'kaboom' },
       },
@@ -1896,7 +1898,7 @@ subtest "friendly duplicate key errors" => sub {
 
 subtest "cannot update a destroyed row" => sub {
   my $create_res = $jmap_tester->request([
-    [ setUsers => {
+    [ 'User/set' => {
       create => {
         first  => { username => 'auser', },
       },
@@ -1910,7 +1912,7 @@ subtest "cannot update a destroyed row" => sub {
 
   # Destroy it
   my $destroy_res = $jmap_tester->request([
-    [ setUsers => {
+    [ 'User/set' => {
       destroy => [ $first_id ],
     } ],
   ]);
@@ -1922,7 +1924,7 @@ subtest "cannot update a destroyed row" => sub {
   );
 
   my $update_res = $jmap_tester->request([
-    [ setUsers => {
+    [ 'User/set' => {
       update => {
         $first_id => { username => 'buser' },
       },
@@ -1943,7 +1945,7 @@ subtest "cannot update a destroyed row" => sub {
 
 subtest "ix_custom_deployment_statements" => sub {
   my $set_res = $jmap_tester->request([
-    [ setUsers => {
+    [ 'User/set' => {
       create => {
         first => { username => 'someuser', },
       },
@@ -1954,21 +1956,22 @@ subtest "ix_custom_deployment_statements" => sub {
   ok(my $id = $set->as_set->created_id('first'), 'created one user');
 
   my $get_res = $jmap_tester->request([
-    [ getUserList => {
+    [ 'User/query' => {
       filter => { username => 'SOMEUSER' },
     } ],
   ]);
 
+  # TODO backrefs -- michael, 2018-05-09
   jcmp_deeply(
-    $get_res->single_sentence->arguments->{userIds},
+    $get_res->single_sentence->arguments->{UserIds},
     [ $id ],
     'Able to grab our user using case-insensitive search'
-  );
+  ) or diag explain $get_res->as_stripped_pairs;
 };
 
 subtest "space cookies (are totally canceled)" => sub {
   my $res = $jmap_tester->request([[
-    setCookies => {
+    'Cookie/set' => {
       outofthisworld => 1,
 
       create => { raw => { type => 'stardust', baked_at => undef } },
@@ -1983,7 +1986,7 @@ subtest "space cookies (are totally canceled)" => sub {
 
 subtest "property canonicalization" => sub {
   my $create_res = $jmap_tester->request([[
-    setCookies => {
+    'Cookie/set' => {
       create => {
         x => { type => 'chocolate-chip cookie' },
         y => { type => 'chocolate-chip' },
@@ -1991,7 +1994,7 @@ subtest "property canonicalization" => sub {
     },
   ]]);
 
-  my $create_set = $create_res->single_sentence('cookiesSet')->as_set;
+  my $create_set = $create_res->single_sentence('Cookie/set')->as_set;
 
   jcmp_deeply(
     $create_set->created->{x},
@@ -2005,7 +2008,7 @@ subtest "property canonicalization" => sub {
   );
 
   my $update_res = $jmap_tester->request([[
-    setCookies => {
+    'Cookie/set' => {
       update => {
         $create_set->created_id('x') => { type => 'chocolate-chip' },
         $create_set->created_id('y') => { type => 'chocolate-chip cookie' },
@@ -2013,7 +2016,7 @@ subtest "property canonicalization" => sub {
     },
   ]]);
 
-  my $update_set = $update_res->single_sentence('cookiesSet')->as_set;
+  my $update_set = $update_res->single_sentence('Cookie/set')->as_set;
 
   is(
     $update_set->old_state,
@@ -2039,14 +2042,14 @@ subtest "lock timeout" => sub {
     my $lock = $schema->resultset('State')->search(
       {
         accountId => $account{accounts}{rjbs},
-        type      => 'cookies',
+        type      => 'Cookie',
       }, {
         for => 'update',
       }
     )->single;
 
     return $jmap_tester->request([[
-      setCookies => {
+      'Cookie/set' => {
         create => { new => { type => 'ginger', baked_at => undef } },
       }
     ]]);
@@ -2064,19 +2067,19 @@ subtest "string normalization" => sub {
   my $nfd_1 = "u\N{COMBINING DIAERESIS}ser";
 
   my $res = $jmap_tester->request([
-    [ setUsers => {
+    [ 'User/set' => {
       create => {
         u_nfc   => { username => $nfc_1 },
       },
     } ],
   ]);
 
-  my $created  = $res->paragraph(0)->single('usersSet')->as_set;
+  my $created  = $res->paragraph(0)->single('User/set')->as_set;
   my $first_id = $created->created_id('u_nfc');
 
   # Now try to create user with other normalization of name.
   $res = $jmap_tester->request([
-    [ setUsers => {
+    [ 'User/set' => {
       create => {
         u_nfd => { username => $nfd_1, },
       },
@@ -2084,7 +2087,7 @@ subtest "string normalization" => sub {
   ]);
 
   my $err = $res->paragraph(0)
-                ->single('usersSet')
+                ->single('User/set')
                 ->as_set
                 ->create_errors;
 
@@ -2106,7 +2109,7 @@ subtest "client may init and/or update" => sub {
   #   type => { client_may_init => 1, client_may_update => 0 }
   #   qty  => { client_may_init => 0, client_may_update => 1 }
   my $res = $jmap_tester->request([
-    [ setBiscuits => {
+    [ 'Biscuit/set' => {
         create => {
            foo => { type => 'anzac' },
            bar => { type => 'anzac', qty => jnum(1) },
@@ -2114,7 +2117,7 @@ subtest "client may init and/or update" => sub {
     } ],
   ]);
 
-  my $set = $res->single_sentence('biscuitsSet')->as_set;
+  my $set = $res->single_sentence('Biscuit/set')->as_set;
 
   # 'foo' created
   my $created_id =  $set->created_id('foo');
@@ -2135,10 +2138,10 @@ subtest "client may init and/or update" => sub {
 
   # 'qty' updated
   my $update_res = $jmap_tester->request([[
-    setBiscuits => { update => { $created_id => { qty => jnum(1) } } }
+    'Biscuit/set' => { update => { $created_id => { qty => jnum(1) } } }
     ]]);
 
-  my $update_set = $update_res->single_sentence('biscuitsSet')->as_set;
+  my $update_set = $update_res->single_sentence('Biscuit/set')->as_set;
 
   jcmp_deeply(
     $update_set->updated,
@@ -2148,10 +2151,10 @@ subtest "client may init and/or update" => sub {
 
   # 'type' notUpdated
   $update_res = $jmap_tester->request([[
-    setBiscuits => { update => { $created_id => { type => 'shortbread' } } }
+    'Biscuit/set' => { update => { $created_id => { type => 'shortbread' } } }
     ]]);
 
-  $update_set = $update_res->single_sentence('biscuitsSet')->as_set;
+  $update_set = $update_res->single_sentence('Biscuit/set')->as_set;
 
   jcmp_deeply(
     $update_set->update_errors->{$created_id},
@@ -2170,7 +2173,7 @@ subtest "client may init and/or update" => sub {
 subtest "is_immutable" => sub {
   my $set_res = $jmap_tester->request([
     [
-      setBiscuits => {
+      'Biscuit/set' => {
         create => {
            foo => { type => 'chicken', size => 'jumbo' },
         },
@@ -2178,28 +2181,28 @@ subtest "is_immutable" => sub {
     ],
   ]);
 
-  my $set = $set_res->single_sentence('biscuitsSet')->as_set;
+  my $set = $set_res->single_sentence('Biscuit/set')->as_set;
 
   my $obj = $set->created->{foo};
   ok($obj, "we create an object for foo");
 
   my $get_res = $jmap_tester->request([
-    [ getBiscuits => { ids => [ $obj->{id} ] } ]
+    [ 'Biscuit/get' => { ids => [ $obj->{id} ] } ]
   ]);
 
   is(
-    $get_res->single_sentence('biscuits')->arguments->{list}[0]{size},
+    $get_res->single_sentence('Biscuit/get')->arguments->{list}[0]{size},
     'jumbo',
     "the size was set properly",
   );
 
   {
     my $update_res = $jmap_tester->request([
-      [ setBiscuits => { update => { $obj->{id} => { size => 'x-large' } } } ]
+      [ 'Biscuit/set' => { update => { $obj->{id} => { size => 'x-large' } } } ]
     ]);
 
     jcmp_deeply(
-      $update_res->single_sentence('biscuitsSet')->arguments->{notUpdated},
+      $update_res->single_sentence('Biscuit/set')->arguments->{notUpdated},
       superhashof({
         $obj->{id} => {
           type => 'invalidProperties',
@@ -2218,7 +2221,7 @@ subtest "is_immutable" => sub {
 
     my $sys_res = $ctx->process_request([
       [
-        setBiscuits => {
+        'Biscuit/set' => {
           accountId => $account{accounts}{rjbs},
           update    => { $obj->{id} => { size => 'x-large' } }
         },
@@ -2230,7 +2233,7 @@ subtest "is_immutable" => sub {
       $sys_res,
       [
         [
-          biscuitsSet => superhashof({
+          'Biscuit/set' => superhashof({
             notUpdated => {
               $obj->{id} => {
                 type => 'invalidProperties',

--- a/t/basic.t
+++ b/t/basic.t
@@ -25,6 +25,8 @@ my $no_updates = any({}, undef);
 my ($app, $jmap_tester) = Bakesale::Test->new_test_app_and_tester;
 \my %account = Bakesale::Test->load_trivial_account($app->processor->schema_connection);
 
+my $accountId = $account{accounts}{rjbs};
+
 $jmap_tester->_set_cookie('bakesaleUserId', $account{users}{rjbs});
 
 {
@@ -140,6 +142,7 @@ $jmap_tester->_set_cookie('bakesaleUserId', $account{users}{rjbs});
       [ 'Cookie/changes' => ignore() ],
       [
         'Cookie/get' => {
+          accountId => $accountId,
           notFound => undef,
           state => 8,
           list  => [
@@ -151,7 +154,7 @@ $jmap_tester->_set_cookie('bakesaleUserId', $account{users}{rjbs});
       ],
     ],
     "a Foo/get call backed by the database",
-  );
+  ) or diag explain $res->as_stripped_triples;
 }
 
 {
@@ -178,6 +181,7 @@ $jmap_tester->_set_cookie('bakesaleUserId', $account{users}{rjbs});
     [
       [
         'Cookie/get' => {
+          accountId => $accountId,
           notFound => [ $does_not_exist ],
           state => 8,
           list  => [
@@ -348,6 +352,7 @@ my @created_ids;
     [
       [
         'Cookie/changes' => {
+          accountId => $accountId,
           oldState => 8,
           newState => 9,
           hasMoreUpdates => bool(0),
@@ -405,6 +410,7 @@ subtest "invalid sinceState" => sub {
     [
       [
         'Cookie/changes' => {
+          accountId => $accountId,
           oldState => 8,
           newState => 9,
           hasMoreUpdates => bool(0),
@@ -865,6 +871,7 @@ subtest "timestamptz field validations" => sub {
     [
       [
         'Cookie/set' => superhashof({
+          accountId => ignore(),
           oldState => ignore(),
           newState => code(sub { $state = $_[0]; 1}),
           created => {
@@ -915,6 +922,7 @@ subtest "timestamptz field validations" => sub {
       [ 'Cookie/changes' => ignore() ],
       [
         'Cookie/get' => {
+          accountId => ignore(),
           notFound => undef,
           state => $state,
           list  => bag(
@@ -955,6 +963,7 @@ subtest "timestamptz field validations" => sub {
     [
       [
         'Cookie/set' => superhashof({
+          accountId => ignore(),
           oldState => $state,
           newState => $state + 1,
           updated => {
@@ -1001,6 +1010,7 @@ subtest "timestamptz field validations" => sub {
       [ 'Cookie/changes' => ignore() ],
       [
         'Cookie/get' => {
+          accountId => ignore(),
           notFound => undef,
           state => $state,
           list  => set(
@@ -1227,6 +1237,7 @@ subtest "various string id tests" => sub {
       [
         'Cake/set',
         {
+          accountId => ignore(),
           'created' => {},
           'destroyed' => [],
           'newState' => ignore(),
@@ -1259,6 +1270,7 @@ subtest "various string id tests" => sub {
       [
         'Cake/get',
         {
+          accountId => ignore(),
           'list' => [],
           'notFound' => [
             'bad'
@@ -1589,6 +1601,7 @@ subtest "ix_created test" => sub {
     [
       [
         'Cookie/set' => superhashof({
+          accountId => ignore(),
           oldState => 0,
           newState => 1,
 
@@ -2058,7 +2071,7 @@ subtest "lock timeout" => sub {
   my $res = $schema->txn_do(sub {
     my $lock = $schema->resultset('State')->search(
       {
-        accountId => $account{accounts}{rjbs},
+        accountId => $accountId,
         type      => 'Cookie',
       }, {
         for => 'update',
@@ -2239,7 +2252,7 @@ subtest "is_immutable" => sub {
     my $sys_res = $ctx->process_request([
       [
         'Biscuit/set' => {
-          accountId => $account{accounts}{rjbs},
+          accountId => $accountId,
           update    => { $obj->{id} => { size => 'x-large' } }
         },
         'x',

--- a/t/context.t
+++ b/t/context.t
@@ -15,7 +15,7 @@ my ($app, $jmap_tester) = Bakesale::Test->new_test_app_and_tester;
 
 {
   # No user cookie, should get 410 response
-  my $res = $jmap_tester->request([[ getCookies => {} ]])->http_response;
+  my $res = $jmap_tester->request([[ 'Cookie/get' => {} ]])->http_response;
   is($res->code, 410, 'got 410 with no cookie');
   is($res->decoded_content, '{}', 'empty json object');
 }
@@ -30,7 +30,7 @@ my ($app, $jmap_tester) = Bakesale::Test->new_test_app_and_tester;
 
   $jmap_tester->ua->default_header('Origin' => 'example.net');
 
-  my $res = $jmap_tester->request([[ getCookies => {} ]])->http_response;
+  my $res = $jmap_tester->request([[ 'Cookie/get' => {} ]])->http_response;
   is($res->code, 410, 'got 410 with bad cookie');
   is($res->decoded_content, '{"error":"bad auth"}', 'got error in body');
 

--- a/t/get_foo_list.t
+++ b/t/get_foo_list.t
@@ -153,6 +153,7 @@ $state =~ s/-\d+//;
   jcmp_deeply(
     $res->single_sentence->arguments,
     {
+      accountId => ignore(),
       ids => [
         ( sort { $a cmp $b } @cake_id{qw(chocolate1 chocolate2)} ),
         $cake_id{pb1},
@@ -186,6 +187,7 @@ $state =~ s/-\d+//;
   jcmp_deeply(
     $res->single_sentence->arguments,
     {
+      accountId => ignore(),
       ids => [
         $cake_id{pb1},
         # These will still be in .id asc order since we always sort on id
@@ -270,6 +272,7 @@ subtest "custom condition builder" => sub {
   jcmp_deeply(
     $res->single_sentence->arguments,
     {
+      accountId => ignore(),
       'ids' => [
         @cake_id{qw(chocolate1 chocolate2 pb1)},
       ],
@@ -305,6 +308,7 @@ subtest "custom condition builder" => sub {
   jcmp_deeply(
     $res->single_sentence->arguments,
     {
+      accountId => ignore(),
       'ids' => [
         @cake_id{qw(chocolate2 chocolate1 pb1)},
       ],
@@ -340,6 +344,7 @@ subtest "custom condition builder" => sub {
   jcmp_deeply(
     $res->single_sentence->arguments,
     {
+      accountId => ignore(),
       'ids' => [
         @cake_id{qw(pb1)},
       ],
@@ -378,6 +383,7 @@ subtest "custom condition builder" => sub {
     jcmp_deeply(
       $res->single_sentence->arguments,
       {
+        accountId => ignore(),
         'ids' => [
           $cid,
         ],
@@ -417,6 +423,7 @@ subtest "custom condition builder" => sub {
   jcmp_deeply(
     $res->sentence(0)->arguments,
     {
+      accountId => ignore(),
       'ids' => [
         @cake_id{qw(pb1)},
       ],
@@ -462,6 +469,7 @@ subtest "custom condition builder" => sub {
   jcmp_deeply(
     $res->sentence(0)->arguments,
     {
+      accountId => ignore(),
       'ids' => [
         @cake_id{qw(pb1)},
       ],
@@ -571,6 +579,7 @@ subtest "custom condition builder" => sub {
   jcmp_deeply(
     $res->single_sentence->arguments,
     {
+      accountId => ignore(),
       'ids' => [
         @cake_id{qw(chocolate2 pb1)},
       ],
@@ -607,6 +616,7 @@ subtest "custom condition builder" => sub {
   jcmp_deeply(
     $res->single_sentence->arguments,
     {
+      accountId => ignore(),
       'added' => [
         {
           'id' => $cake_id{chocolate2},
@@ -647,6 +657,7 @@ subtest "custom condition builder" => sub {
   jcmp_deeply(
     $res->single_sentence->arguments,
     {
+      accountId => ignore(),
       'added' => [],
       'filter' => {
         'recipeId' => $secret1_recipe_id,
@@ -703,6 +714,7 @@ subtest "custom condition builder" => sub {
   jcmp_deeply(
     $res->single_sentence->arguments,
     {
+      accountId => ignore(),
       'added' => [],
       'filter' => {
         'recipeId' => $secret1_recipe_id,
@@ -756,6 +768,7 @@ subtest "custom condition builder" => sub {
   jcmp_deeply(
     $res->single_sentence->arguments,
     {
+      accountId => ignore(),
       'added' => [
         {
           'id' => $cake_id{pb1},
@@ -840,6 +853,7 @@ subtest "custom condition builder" => sub {
   jcmp_deeply(
     $res->sentence(0)->arguments,
     {
+      accountId => ignore(),
       'ids' => [
         @cake_id{qw(pb1)},
       ],
@@ -890,6 +904,7 @@ subtest "custom condition builder" => sub {
   jcmp_deeply(
     $res->sentence(0)->arguments,
     {
+      accountId => ignore(),
       'ids' => [
         @cake_id{qw(pb1)},
       ],
@@ -1073,6 +1088,7 @@ subtest "filters on joined tables" => sub {
     jcmp_deeply(
       $res->single_sentence->arguments,
       {
+        accountId => ignore(),
         'ids' => [
           $cake_id{chocolate2},
           $cake_id{pb1},
@@ -1107,6 +1123,7 @@ subtest "filters on joined tables" => sub {
     jcmp_deeply(
       $res->single_sentence->arguments,
       {
+        accountId => ignore(),
         'added' => [
           {
             'id' => $cake_id{chocolate2},
@@ -1147,6 +1164,7 @@ subtest "filters on joined tables" => sub {
     jcmp_deeply(
       $res->single_sentence->arguments,
       {
+        accountId => ignore(),
         'ids' => [],
         'filter' => {
           'recipeId' => $secret1_recipe_id,
@@ -1217,6 +1235,7 @@ subtest "differ boolean comparison when db row is false" => sub {
     jcmp_deeply(
       $res->single_sentence->arguments,
       {
+        accountId => ignore(),
         'added' => set(
           superhashof({
             'id' => $cake_id{marble1},
@@ -1265,6 +1284,7 @@ subtest "differ boolean comparison when db row is false" => sub {
     jcmp_deeply(
       $res->single_sentence->arguments,
       {
+        accountId => ignore(),
         'added' => [],
         'filter' => {
           'recipeId' => $secret2_recipe_id,
@@ -1298,6 +1318,7 @@ subtest "differ boolean comparison when db row is false" => sub {
     jcmp_deeply(
       $res->single_sentence->arguments,
       {
+        accountId => ignore(),
         'added' => [],
         'filter' => {
           'recipeId' => $secret2_recipe_id,

--- a/t/get_foo_list.t
+++ b/t/get_foo_list.t
@@ -600,11 +600,11 @@ subtest "custom condition builder" => sub {
     {
       'added' => [
         {
-          'CakeId' => $cake_id{chocolate2},
+          'id' => $cake_id{chocolate2},
           'index' => 0,
         },
         {
-          'CakeId' => $cake_id{pb1},
+          'id' => $cake_id{pb1},
           'index' => 1,
         }
       ],
@@ -753,7 +753,7 @@ subtest "custom condition builder" => sub {
     {
       'added' => [
         {
-          'CakeId' => $cake_id{pb1},  # XXX backrefs
+          'id' => $cake_id{pb1},
           'index' => 1,
         },
       ],
@@ -988,10 +988,10 @@ subtest 'custom differ, and no required filters' => sub {
         added => [
           {
             index => 0,
-            CookieId => $oatmeal,
+            id => $oatmeal,
           }, {
             index => 1,
-            CookieId => $oreo,
+            id => $oreo,
           }
         ],
         removed => [ ],
@@ -1040,7 +1040,7 @@ subtest 'custom differ, and no required filters' => sub {
         added => [
           {
             index => 0,
-            CookieId => $peanut,
+            id => $peanut,
           },
         ],
         removed => [
@@ -1108,11 +1108,11 @@ subtest "filters on joined tables" => sub {
       {
         'added' => [
           {
-            'CakeId' => $cake_id{chocolate2},
+            'id' => $cake_id{chocolate2},
             'index' => 0,
           },
           {
-            'CakeId' => $cake_id{pb1},
+            'id' => $cake_id{pb1},
             'index' => 1,
           }
         ],
@@ -1220,14 +1220,14 @@ subtest "differ boolean comparison when db row is false" => sub {
       {
         'added' => set(
           superhashof({
-            'CakeId' => $cake_id{marble1},
+            'id' => $cake_id{marble1},
           }),
           superhashof({
-            'CakeId' => $cake_id{marble2},
+            'id' => $cake_id{marble2},
             'index'  => ignore(),
           }),
           superhashof({
-            'CakeId' => $cake_id{lemon1},
+            'id' => $cake_id{lemon1},
             'index'  => ignore(),
           }),
         ),
@@ -1367,7 +1367,7 @@ subtest "distinct rows only" => sub {
         map {;
           {
             index  => ignore(),
-            CakeId => $_
+            id => $_
           },
         } sort { $a cmp $b } values %cake_id,
       ],

--- a/t/get_foo_list.t
+++ b/t/get_foo_list.t
@@ -58,7 +58,7 @@ ok($secret2_recipe_id, 'created a marble recipe');
         filter => {
           recipeId => $secret1_recipe_id,
         },
-        sort => [ 'created asc' ],
+        sort => [{ property => 'created', isAscending => jtrue }],
       },
     ],
   ]);
@@ -79,7 +79,7 @@ ok($secret2_recipe_id, 'created a marble recipe');
         filter => {
           recipeId => $secret1_recipe_id,
         },
-        sort => [ 'created asc' ],
+        sort => [{ property => 'created', isAscending => jtrue }],
         sinceState => 0,
       },
     ],
@@ -97,7 +97,6 @@ ok($secret2_recipe_id, 'created a marble recipe');
     "ix_get_list_update works with no state rows"
   );
 }
-
 
 # Now create a few cakes under each one
 $res = $jmap_tester->request([
@@ -146,7 +145,7 @@ $state =~ s/-\d+//;
         filter => {
           recipeId => $secret1_recipe_id,
         },
-        sort => [ 'type asc' ],
+        sort => [{ property => 'type', isAscending => jtrue }],
       },
     ],
   ]);
@@ -164,7 +163,7 @@ $state =~ s/-\d+//;
       'canCalculateUpdates' => jtrue,
       'position' => 0,
       'sort' => [
-        'type asc',
+        { property => 'type', isAscending => jtrue },
       ],
       'state' => $state,
       'total' => 3,
@@ -179,7 +178,7 @@ $state =~ s/-\d+//;
         filter => {
           recipeId => $secret1_recipe_id,
         },
-        sort => [ 'type desc' ],
+        sort => [{ property => 'type', isAscending => jfalse }],
       },
     ],
   ]);
@@ -200,7 +199,7 @@ $state =~ s/-\d+//;
       'canCalculateUpdates' => jtrue,
       'position' => 0,
       'sort' => [
-        'type desc'
+        { property => 'type', isAscending => jfalse }
       ],
       'state' => $state,
       'total' => 3,
@@ -260,7 +259,10 @@ subtest "custom condition builder" => sub {
         filter => {
           recipeId => $secret1_recipe_id,
         },
-        sort => [ 'type asc', 'layer_count asc' ],
+        sort => [
+          { property => 'type',        isAscending => jtrue },
+          { property => 'layer_count', isAscending => jtrue },
+        ],
       },
     ],
   ]);
@@ -277,8 +279,8 @@ subtest "custom condition builder" => sub {
       'canCalculateUpdates' => jtrue,
       'position' => 0,
       'sort' => [
-        'type asc',
-        'layer_count asc',
+        { property => 'type',        isAscending => jtrue },
+        { property => 'layer_count', isAscending => jtrue },
       ],
       'state' => $state,
       'total' => 3,
@@ -292,7 +294,10 @@ subtest "custom condition builder" => sub {
         filter => {
           recipeId => $secret1_recipe_id,
         },
-        sort => [ 'type asc', 'layer_count desc' ],
+        sort => [
+          { property => 'type',        isAscending => jtrue },
+          { property => 'layer_count', isAscending => jfalse },
+        ],
       },
     ],
   ]);
@@ -309,8 +314,8 @@ subtest "custom condition builder" => sub {
       'canCalculateUpdates' => jtrue,
       'position' => 0,
       'sort' => [
-        'type asc',
-        'layer_count desc',
+        { property => 'type',        isAscending => jtrue },
+        { property => 'layer_count', isAscending => jfalse },
       ],
       'state' => $state,
       'total' => 3,
@@ -505,7 +510,12 @@ subtest "custom condition builder" => sub {
         filter => {
           fake => 'not a real field',
         },
-        sort => [ 'type', 'fake asc', 'layer_count asc bad', 'layer_count bad' ],
+        sort => [
+          { property => 'type' },   # this is fine; defaults to ascending
+          { property => 'fake', isAscending => jtrue },
+          { property => 'fake', isAscending => jtrue, bad => 'foo' },
+          { property => 'fake', bad => 'foo' },
+        ]
       },
     ],
   ]);
@@ -519,12 +529,11 @@ subtest "custom condition builder" => sub {
         'fake'     => 'unknown filter field',
         'recipeId' => 'required filter missing',
       },
-      'invalidSorts' => {
-        'fake asc'    => 'unknown sort field',
-        'type'        => 'invalid sort format: missing sort order',
-        'layer_count bad' => "invalid sort format: sort order must be 'asc' or 'desc'",
-        'layer_count asc bad' => "invalid sort format: expected exactly two arguments",
-      },
+      'invalidSorts' => [
+        "unknown sort field 'fake'",
+        "invalid sort format: unknown arguments [bad]",
+        "invalid sort format: unknown arguments [bad]",
+      ],
     },
     "bad /query forms detected",
   ) or diag explain $res->as_stripped_triples;
@@ -554,7 +563,7 @@ subtest "custom condition builder" => sub {
         filter => {
           recipeId => $secret1_recipe_id,
         },
-        sort => [ 'type asc' ],
+        sort => [{ property => 'type', isAscending => jtrue }],
       },
     ],
   ]);
@@ -571,7 +580,7 @@ subtest "custom condition builder" => sub {
       'canCalculateUpdates' => jtrue,
       'position' => 0,
       'sort' => [
-        'type asc',
+        { property => 'type', isAscending => jtrue },
       ],
       'state' => $state,
       'total' => 2,
@@ -589,7 +598,7 @@ subtest "custom condition builder" => sub {
         filter => {
           recipeId => $secret1_recipe_id,
         },
-        sort => [ 'type asc' ],
+        sort => [{ property => 'type', isAscending => jtrue }],
         sinceState => $state - 2,
       },
     ],
@@ -615,7 +624,7 @@ subtest "custom condition builder" => sub {
       'oldState' => jstr($state-2),
       'removed' => [],
       'sort' => [
-        'type asc'
+        { property => 'type', isAscending => jtrue },
       ],
       'total' => 2
     },
@@ -629,7 +638,7 @@ subtest "custom condition builder" => sub {
         filter => {
           recipeId => $secret1_recipe_id,
         },
-        sort => [ 'type asc' ],
+        sort => [{ property => 'type', isAscending => jtrue }],
         sinceState => $state - 1,
       },
     ],
@@ -647,9 +656,7 @@ subtest "custom condition builder" => sub {
       'removed' => [
         $cake_id{chocolate1},
       ],
-      'sort' => [
-        'type asc'
-      ],
+      sort => [{ property => 'type', isAscending => jtrue }],
       'total' => 2
     },
     "Cake/queryChanges looks right for removed cake"
@@ -664,7 +671,7 @@ subtest "custom condition builder" => sub {
         filter => {
           recipeId => $secret1_recipe_id,
         },
-        sort => [ 'type asc' ],
+        sort => [{ property => 'type', isAscending => jtrue }],
       },
     ],
   ]);
@@ -687,7 +694,7 @@ subtest "custom condition builder" => sub {
         filter => {
           recipeId => $secret1_recipe_id,
         },
-        sort => [ 'type asc' ],
+        sort => [{ property => 'type', isAscending => jtrue }],
         sinceState => $state,
       },
     ],
@@ -703,9 +710,7 @@ subtest "custom condition builder" => sub {
       'newState' => jstr($state),
       'oldState' => jstr($state),
       'removed' => [],
-      'sort' => [
-        'type asc'
-      ],
+      'sort'    => [{ property => 'type', isAscending => jtrue }],
       'total' => 2
     },
     "Cake/queryChanges looks right for no changes"
@@ -741,7 +746,7 @@ subtest "custom condition builder" => sub {
         filter => {
           recipeId => $secret1_recipe_id,
         },
-        sort => [ 'type asc' ],
+        sort => [{ property => 'type', isAscending => jtrue }],
         sinceState => $state-1,
       },
     ],
@@ -765,9 +770,7 @@ subtest "custom condition builder" => sub {
       'removed' => [
         $cake_id{pb1},
       ],
-      'sort' => [
-        'type asc'
-      ],
+      'sort'  => [{ property => 'type', isAscending => jtrue }],
       'total' => 2
     },
     "Cake/queryChanges looks right for no changes"
@@ -927,7 +930,7 @@ subtest 'custom differ, and no required filters' => sub {
       types => [ 'oatmeal stout', 'oreo stout' ],
       batch => $Bakesale::Schema::Result::Cookie::next_batch,
     },
-    sort   => [ "type asc" ],
+    sort   => [{ property => 'type', isAscending => jtrue }],
   );
 
   {
@@ -1062,7 +1065,7 @@ subtest "filters on joined tables" => sub {
             'recipeId' => $secret1_recipe_id,
             'recipe.is_delicious' => jtrue,
           },
-          sort => [ 'type asc' ],
+          sort => [{ property => 'type', isAscending => jtrue }],
         },
       ],
     ]);
@@ -1081,9 +1084,7 @@ subtest "filters on joined tables" => sub {
         },
         'canCalculateUpdates' => jtrue,
         'position' => 0,
-        'sort' => [
-          'type asc',
-        ],
+        'sort'  => [{ property => 'type', isAscending => jtrue }],
         'state' => $state,
         'total' => 2,
       },
@@ -1097,7 +1098,7 @@ subtest "filters on joined tables" => sub {
             recipeId => $secret1_recipe_id,
             'recipe.is_delicious' => jtrue,
           },
-          sort => [ 'type asc' ],
+          sort => [{ property => 'type', isAscending => jtrue }],
           sinceState => $state - 3,
         },
       ],
@@ -1123,9 +1124,7 @@ subtest "filters on joined tables" => sub {
         'newState' => $state,
         'oldState' => $state - 3,
         'removed' => [],
-        'sort' => [
-          'type asc'
-        ],
+        'sort'  => [{ property => 'type', isAscending => jtrue }],
         'total' => 2
       },
       "Cake/queryChanges with filter on join with match looks right"
@@ -1140,7 +1139,7 @@ subtest "filters on joined tables" => sub {
             'recipeId' => $secret1_recipe_id,
             'recipe.is_delicious' => jfalse, # But these are delicious!
           },
-          sort => [ 'type asc' ],
+          sort => [{ property => 'type', isAscending => jtrue }],
         },
       ],
     ]);
@@ -1156,7 +1155,7 @@ subtest "filters on joined tables" => sub {
         'canCalculateUpdates' => jtrue,
         'position' => 0,
         'sort' => [
-          'type asc',
+          { property => 'type', isAscending => jtrue },
         ],
         'state' => $state,
         'total' => 0,
@@ -1171,7 +1170,7 @@ subtest "filters on joined tables" => sub {
             recipeId => $secret1_recipe_id,
             'recipe.is_delicious' => jfalse,
           },
-          sort => [ 'type asc' ],
+          sort => [{ property => 'type', isAscending => jtrue }],
           sinceState => $state - 3,
         },
       ],
@@ -1209,7 +1208,7 @@ subtest "differ boolean comparison when db row is false" => sub {
             recipeId => $secret2_recipe_id,
             'recipe.is_delicious' => jfalse,
           },
-          sort => [ 'type asc' ],
+          sort => [{ property => 'type', isAscending => jtrue }],
           sinceState => $state - 3,
         },
       ],
@@ -1239,7 +1238,7 @@ subtest "differ boolean comparison when db row is false" => sub {
         'oldState' => $state - 3,
         'removed' => [],
         'sort' => [
-          'type asc'
+          { property => 'type', isAscending => jtrue },
         ],
         'total' => 3,
       },
@@ -1257,7 +1256,7 @@ subtest "differ boolean comparison when db row is false" => sub {
             recipeId => $secret2_recipe_id,
             'recipe.is_delicious' => jtrue,
           },
-          sort => [ 'type asc' ],
+          sort => [{ property => 'type', isAscending => jtrue }],
           sinceState => $state - 3,
         },
       ],
@@ -1275,7 +1274,7 @@ subtest "differ boolean comparison when db row is false" => sub {
         'oldState' => $state - 3,
         'removed' => [],
         'sort' => [
-          'type asc'
+          { property => 'type', isAscending => jtrue },
         ],
         'total' => 0,
       },
@@ -1290,7 +1289,7 @@ subtest "differ boolean comparison when db row is false" => sub {
             recipeId => $secret2_recipe_id,
             'recipe.is_delicious' => jtrue,
           },
-          sort => [ 'type asc' ],
+          sort => [{ property => 'type', isAscending => jtrue }],
           sinceState => $state - 2,
         },
       ],
@@ -1308,7 +1307,7 @@ subtest "differ boolean comparison when db row is false" => sub {
         'oldState' => $state - 2,
         'removed' => [],
         'sort' => [
-          'type asc'
+          { property => 'type', isAscending => jtrue },
         ],
         'total' => 0,
       },
@@ -1337,7 +1336,7 @@ subtest "distinct rows only" => sub {
   $res = $jmap_tester->request([
     [
       'Cake/query' => {
-        sort => [ 'id asc' ],
+        sort => [{ property => 'id', isAscending => jtrue }],
       },
     ],
   ]);
@@ -1355,7 +1354,7 @@ subtest "distinct rows only" => sub {
   $res = $jmap_tester->request([
     [
       'Cake/queryChanges' => {
-        sort => [ 'id asc' ],
+        sort => [{ property => 'id', isAscending => jtrue }],
         sinceState => 0,
       },
     ],

--- a/t/get_foo_list.t
+++ b/t/get_foo_list.t
@@ -66,9 +66,9 @@ ok($secret2_recipe_id, 'created a marble recipe');
   jcmp_deeply(
     $res->single_sentence->arguments,
     superhashof({
-      ids     => [],
-      state   => 0,
-      total   => 0,
+      ids        => [],
+      queryState => 0,
+      total      => 0,
     }),
     "ix_get_list works with no state rows"
   );
@@ -80,7 +80,7 @@ ok($secret2_recipe_id, 'created a marble recipe');
           recipeId => $secret1_recipe_id,
         },
         sort => [{ property => 'created', isAscending => jtrue }],
-        sinceState => 0,
+        sinceQueryState => 0,
       },
     ],
   ]);
@@ -91,8 +91,8 @@ ok($secret2_recipe_id, 'created a marble recipe');
       added    => [],
       removed  => [],
       total    => 0,
-      newState => 0,
-      oldState => 0,
+      newQueryState => 0,
+      oldQueryState => 0,
     }),
     "ix_get_list_update works with no state rows"
   );
@@ -165,7 +165,7 @@ $state =~ s/-\d+//;
       'sort' => [
         { property => 'type', isAscending => jtrue },
       ],
-      'state' => $state,
+      'queryState' => $state,
       'total' => 3,
     },
     "Cake/query with sort+filter looks right"
@@ -201,7 +201,7 @@ $state =~ s/-\d+//;
       'sort' => [
         { property => 'type', isAscending => jfalse }
       ],
-      'state' => $state,
+      'queryState' => $state,
       'total' => 3,
     },
     "Cake/query with sort+filter looks right (reverse sort)"
@@ -282,7 +282,7 @@ subtest "custom condition builder" => sub {
         { property => 'type',        isAscending => jtrue },
         { property => 'layer_count', isAscending => jtrue },
       ],
-      'state' => $state,
+      'queryState' => $state,
       'total' => 3,
     },
     "Cake/query with multi-sort + filter looks right"
@@ -317,7 +317,7 @@ subtest "custom condition builder" => sub {
         { property => 'type',        isAscending => jtrue },
         { property => 'layer_count', isAscending => jfalse },
       ],
-      'state' => $state,
+      'queryState' => $state,
       'total' => 3,
     },
     "Cake/query with multi-sort + filter looks right"
@@ -350,7 +350,7 @@ subtest "custom condition builder" => sub {
       'canCalculateUpdates' => jtrue,
       'position' => 0,
       'sort' => undef,
-      'state' => $state,
+      'queryState' => $state,
       'total' => 1,
     },
     "Cake/query with no sort, multi-filter"
@@ -387,7 +387,7 @@ subtest "custom condition builder" => sub {
         'canCalculateUpdates' => jtrue,
         'position' => $p-1,
         'sort' => [],
-        'state' => $state,
+        'queryState' => $state,
         'total' => 3,
       },
       "Cake/query with limit 1, position $p looks right (got cake $cid)"
@@ -427,7 +427,7 @@ subtest "custom condition builder" => sub {
       'canCalculateUpdates' => jtrue,
       'position' => 0,
       'sort' => undef,
-      'state' => $state,
+      'queryState' => $state,
       'total' => 1,
     },
     "'Cake/query' with backrefs"
@@ -472,7 +472,7 @@ subtest "custom condition builder" => sub {
       'canCalculateUpdates' => jtrue,
       'position' => 0,
       'sort' => undef,
-      'state' => $state,
+      'queryState' => $state,
       'total' => 1,
     },
     "Cake/query with backrefs"
@@ -582,7 +582,7 @@ subtest "custom condition builder" => sub {
       'sort' => [
         { property => 'type', isAscending => jtrue },
       ],
-      'state' => $state,
+      'queryState' => $state,
       'total' => 2,
     },
     "Cake/query doesn't show destroyed cakes"
@@ -599,7 +599,7 @@ subtest "custom condition builder" => sub {
           recipeId => $secret1_recipe_id,
         },
         sort => [{ property => 'type', isAscending => jtrue }],
-        sinceState => $state - 2,
+        sinceQueryState => $state - 2,
       },
     ],
   ]);
@@ -620,8 +620,8 @@ subtest "custom condition builder" => sub {
       'filter' => {
         'recipeId' => $secret1_recipe_id,
       },
-      'newState' => jstr($state),
-      'oldState' => jstr($state-2),
+      'newQueryState' => jstr($state),
+      'oldQueryState' => jstr($state-2),
       'removed' => [],
       'sort' => [
         { property => 'type', isAscending => jtrue },
@@ -639,7 +639,7 @@ subtest "custom condition builder" => sub {
           recipeId => $secret1_recipe_id,
         },
         sort => [{ property => 'type', isAscending => jtrue }],
-        sinceState => $state - 1,
+        sinceQueryState => $state - 1,
       },
     ],
   ]);
@@ -651,8 +651,8 @@ subtest "custom condition builder" => sub {
       'filter' => {
         'recipeId' => $secret1_recipe_id,
       },
-      'newState' => jstr($state),
-      'oldState' => jstr($state-1),
+      'newQueryState' => jstr($state),
+      'oldQueryState' => jstr($state-1),
       'removed' => [
         $cake_id{chocolate1},
       ],
@@ -680,14 +680,14 @@ subtest "custom condition builder" => sub {
     $res->single_sentence->arguments,
     {
       'type' => 'invalidArguments',
-      'description' => 'no sinceState given',
+      'description' => 'no sinceQueryState given',
     },
-    "No sinceState - correct error",
+    "No sinceQueryState - correct error",
   );
 }
 
 {
-  # sinceState up to date
+  # sinceQueryState up to date
   $res = $jmap_tester->request([
     [
       'Cake/queryChanges' => {
@@ -695,7 +695,7 @@ subtest "custom condition builder" => sub {
           recipeId => $secret1_recipe_id,
         },
         sort => [{ property => 'type', isAscending => jtrue }],
-        sinceState => $state,
+        sinceQueryState => $state,
       },
     ],
   ]);
@@ -707,8 +707,8 @@ subtest "custom condition builder" => sub {
       'filter' => {
         'recipeId' => $secret1_recipe_id,
       },
-      'newState' => jstr($state),
-      'oldState' => jstr($state),
+      'newQueryState' => jstr($state),
+      'oldQueryState' => jstr($state),
       'removed' => [],
       'sort'    => [{ property => 'type', isAscending => jtrue }],
       'total' => 2
@@ -747,7 +747,7 @@ subtest "custom condition builder" => sub {
           recipeId => $secret1_recipe_id,
         },
         sort => [{ property => 'type', isAscending => jtrue }],
-        sinceState => $state-1,
+        sinceQueryState => $state-1,
       },
     ],
   ]);
@@ -765,8 +765,8 @@ subtest "custom condition builder" => sub {
       'filter' => {
         'recipeId' => $secret1_recipe_id,
       },
-      'newState' => $state,
-      'oldState' => $state-1,
+      'newQueryState' => $state,
+      'oldQueryState' => $state-1,
       'removed' => [
         $cake_id{pb1},
       ],
@@ -792,7 +792,7 @@ subtest "custom condition builder" => sub {
         filter => {
           recipeId => 'secret',
         },
-        sinceState => $state-1,
+        sinceQueryState => $state-1,
       },
     ],
   ]);
@@ -850,7 +850,7 @@ subtest "custom condition builder" => sub {
       'canCalculateUpdates' => JSON::MaybeXS::JSON->true,
       'position' => 0,
       'sort' => undef,
-      'state' => $state,
+      'queryState' => $state,
       'total' => 1,
     },
     "Cake/query with properties in backref"
@@ -900,7 +900,7 @@ subtest "custom condition builder" => sub {
       'canCalculateUpdates' => JSON::MaybeXS::JSON->true,
       'position' => 0,
       'sort' => undef,
-      'state' => $state,
+      'queryState' => $state,
       'total' => 1,
     },
     "Cake/query with explicit CakeRecipe/get"
@@ -947,7 +947,7 @@ subtest 'custom differ, and no required filters' => sub {
       "No cookies match our filter yet"
     ) or diag explain $cl_res->as_stripped_triples;
 
-    my $base_state = $cl_res->single_sentence->arguments->{state};
+    my $base_state = $cl_res->single_sentence->arguments->{queryState};
     ok(defined $base_state, 'got cookie state');
 
     push @states, $base_state;
@@ -981,7 +981,7 @@ subtest 'custom differ, and no required filters' => sub {
     my $clu_res = $jmap_tester->request([[
       'Cookie/queryChanges' => {
         %cl_args,
-        sinceState => $states[0],
+        sinceQueryState => $states[0],
       },
     ]]);
 
@@ -1002,7 +1002,7 @@ subtest 'custom differ, and no required filters' => sub {
       "Got two cookies out of three"
     ) or diag explain $clu_res->as_stripped_triples;
 
-    my $state = $clu_res->single_sentence->arguments->{newState};
+    my $state = $clu_res->single_sentence->arguments->{newQueryState};
     ok(defined $state, 'got next cookie state')
       or diag explain $clu_res->as_stripped_triples;
 
@@ -1033,7 +1033,7 @@ subtest 'custom differ, and no required filters' => sub {
     my $clu_res = $jmap_tester->request([[
       'Cookie/queryChanges' => {
         %cl_args,
-        sinceState => $states[-1],
+        sinceQueryState => $states[-1],
       },
     ]]);
 
@@ -1085,7 +1085,7 @@ subtest "filters on joined tables" => sub {
         'canCalculateUpdates' => jtrue,
         'position' => 0,
         'sort'  => [{ property => 'type', isAscending => jtrue }],
-        'state' => $state,
+        'queryState' => $state,
         'total' => 2,
       },
       "Cake/query with filter on join with match looks right"
@@ -1099,7 +1099,7 @@ subtest "filters on joined tables" => sub {
             'recipe.is_delicious' => jtrue,
           },
           sort => [{ property => 'type', isAscending => jtrue }],
-          sinceState => $state - 3,
+          sinceQueryState => $state - 3,
         },
       ],
     ]);
@@ -1121,8 +1121,8 @@ subtest "filters on joined tables" => sub {
           'recipeId' => $secret1_recipe_id,
           'recipe.is_delicious' => jtrue,
         },
-        'newState' => $state,
-        'oldState' => $state - 3,
+        'newQueryState' => $state,
+        'oldQueryState' => $state - 3,
         'removed' => [],
         'sort'  => [{ property => 'type', isAscending => jtrue }],
         'total' => 2
@@ -1157,7 +1157,7 @@ subtest "filters on joined tables" => sub {
         'sort' => [
           { property => 'type', isAscending => jtrue },
         ],
-        'state' => $state,
+        'queryState' => $state,
         'total' => 0,
       },
       "Cake/query with filter on join no match looks right"
@@ -1171,7 +1171,7 @@ subtest "filters on joined tables" => sub {
             'recipe.is_delicious' => jfalse,
           },
           sort => [{ property => 'type', isAscending => jtrue }],
-          sinceState => $state - 3,
+          sinceQueryState => $state - 3,
         },
       ],
     ]);
@@ -1182,8 +1182,8 @@ subtest "filters on joined tables" => sub {
         added    => [],
         removed  => [],
         total    => 0,
-        newState => $state,
-        oldState => $state - 3,
+        newQueryState => $state,
+        oldQueryState => $state - 3,
         filter => {
           recipeId => $secret1_recipe_id,
           'recipe.is_delicious' => jfalse,
@@ -1209,7 +1209,7 @@ subtest "differ boolean comparison when db row is false" => sub {
             'recipe.is_delicious' => jfalse,
           },
           sort => [{ property => 'type', isAscending => jtrue }],
-          sinceState => $state - 3,
+          sinceQueryState => $state - 3,
         },
       ],
     ]);
@@ -1234,8 +1234,8 @@ subtest "differ boolean comparison when db row is false" => sub {
           'recipeId' => $secret2_recipe_id,
           'recipe.is_delicious' => jfalse,
         },
-        'newState' => $state,
-        'oldState' => $state - 3,
+        'newQueryState' => $state,
+        'oldQueryState' => $state - 3,
         'removed' => [],
         'sort' => [
           { property => 'type', isAscending => jtrue },
@@ -1257,7 +1257,7 @@ subtest "differ boolean comparison when db row is false" => sub {
             'recipe.is_delicious' => jtrue,
           },
           sort => [{ property => 'type', isAscending => jtrue }],
-          sinceState => $state - 3,
+          sinceQueryState => $state - 3,
         },
       ],
     ]);
@@ -1270,8 +1270,8 @@ subtest "differ boolean comparison when db row is false" => sub {
           'recipeId' => $secret2_recipe_id,
           'recipe.is_delicious' => jtrue,
         },
-        'newState' => $state,
-        'oldState' => $state - 3,
+        'newQueryState' => $state,
+        'oldQueryState' => $state - 3,
         'removed' => [],
         'sort' => [
           { property => 'type', isAscending => jtrue },
@@ -1290,7 +1290,7 @@ subtest "differ boolean comparison when db row is false" => sub {
             'recipe.is_delicious' => jtrue,
           },
           sort => [{ property => 'type', isAscending => jtrue }],
-          sinceState => $state - 2,
+          sinceQueryState => $state - 2,
         },
       ],
     ]);
@@ -1303,8 +1303,8 @@ subtest "differ boolean comparison when db row is false" => sub {
           'recipeId' => $secret2_recipe_id,
           'recipe.is_delicious' => jtrue,
         },
-        'newState' => $state,
-        'oldState' => $state - 2,
+        'newQueryState' => $state,
+        'oldQueryState' => $state - 2,
         'removed' => [],
         'sort' => [
           { property => 'type', isAscending => jtrue },
@@ -1355,7 +1355,7 @@ subtest "distinct rows only" => sub {
     [
       'Cake/queryChanges' => {
         sort => [{ property => 'id', isAscending => jtrue }],
-        sinceState => 0,
+        sinceQueryState => 0,
       },
     ],
   ]);
@@ -1381,7 +1381,7 @@ subtest "tooManyChanges" => sub {
     my $res = $jmap_tester->request([[
       'Cake/queryChanges' => {
         filter => { recipeId => $secret1_recipe_id, },
-        sinceState => 1,
+        sinceQueryState => 1,
         maxChanges => 100,
       },
     ]]);
@@ -1393,14 +1393,14 @@ subtest "tooManyChanges" => sub {
         removed => [ ignore(), ignore() ],
       }),
       'got a good response, with both added/removed elements'
-    );
+    ) or diag explain $res->as_stripped_triples;
   };
 
   subtest "Exact amount of changes" => sub {
     my $res = $jmap_tester->request([[
       'Cake/queryChanges' => {
         filter => { recipeId => $secret1_recipe_id, },
-        sinceState => 1,
+        sinceQueryState => 1,
         maxChanges => 3,
       },
     ]]);
@@ -1419,7 +1419,7 @@ subtest "tooManyChanges" => sub {
     my $res = $jmap_tester->request([[
       'Cake/queryChanges' => {
         filter => { recipeId => $secret1_recipe_id, },
-        sinceState => 1,
+        sinceQueryState => 1,
         maxChanges => 2,
       },
     ]]);
@@ -1439,7 +1439,7 @@ subtest "custom cake differ" => sub {
         recipeId => $secret1_recipe_id,
         isLayered             => jtrue,
         'recipe.is_delicious' => jtrue,
-      }, sinceState => 0 }
+      }, sinceQueryState => 0 }
     ],
   ]);
   ok($res->http_response->is_success, 'call succeeded');
@@ -1457,10 +1457,10 @@ subtest "we do not promote undef sort or filter" => sub {
 
       jcmp_deeply($list->arguments->{filter}, $value, "Foo/query filter");
 
-      my $state = $list->arguments->{state};
+      my $state = $list->arguments->{queryState};
 
       my $listup_res = $jmap_tester->request([
-        [ 'Cookie/queryChanges' => { sinceState => $state, filter => $value } ]
+        [ 'Cookie/queryChanges' => { sinceQueryState => $state, filter => $value } ]
       ]);
 
       my $listup = $listup_res->single_sentence('Cookie/queryChanges');

--- a/t/get_foo_list.t
+++ b/t/get_foo_list.t
@@ -390,9 +390,6 @@ subtest "custom condition builder" => sub {
   }
 }
 
-# XXX - Test for limit set at 500 if fetching extras
-#       -- alh, 2016-11-22
-
 {
   # backrefs (on old-style jmap: was fetchCakes)
   $res = $jmap_tester->request([
@@ -868,7 +865,7 @@ subtest "custom condition builder" => sub {
     "got cake back with backrefs"
   ) or diag explain $res->as_stripped_triples;
 
-  # was: fetchOtherFooProperties
+  # backrefs (on old-style jmap: was fetchOtherFooProperties)
   $res = $jmap_tester->request([
     [
       'Cake/query' => {

--- a/t/lib/Bakesale.pm
+++ b/t/lib/Bakesale.pm
@@ -131,19 +131,19 @@ package Bakesale::Test {
     ]);
 
     $schema->resultset('State')->search({
-      accountId => $a1, type => 'cookies',
+      accountId => $a1, type => 'Cookie',
     })->update({ highestModSeq => 8 });
 
     $schema->resultset('State')->search({
-      accountId => $a2, type => 'cookies',
+      accountId => $a2, type => 'Cookie',
     })->update({ highestModSeq => 1 });
 
     $schema->resultset('State')->search({
-      accountId => $a1, type => 'users',
+      accountId => $a1, type => 'User',
     })->update({ highestModSeq => 1 });
 
     $schema->resultset('State')->search({
-      accountId => $a1, type => 'users',
+      accountId => $a1, type => 'User',
     })->update({ highestModSeq => 1 });
 
     return {

--- a/t/lib/Bakesale/Context.pm
+++ b/t/lib/Bakesale/Context.pm
@@ -25,7 +25,7 @@ package Bakesale::Context {;
     writer   => '_set_user',
     init_arg => undef,
     lazy     => 1,
-    clearer  => '_clear_user', # trigger this after setUsers, surely?
+    clearer  => '_clear_user', # trigger this after User/set, surely?
     default  => sub ($self) {
       return $self->schema->resultset('User')->find($self->userId);
     },

--- a/t/lib/Bakesale/Context.pm
+++ b/t/lib/Bakesale/Context.pm
@@ -49,7 +49,7 @@ package Bakesale::Context {;
 
   sub may_call ($self, $method, $arg) {
     # We don't have the tech to create space cookies
-    if ($method eq 'setCookies' && $arg->{outofthisworld}) {
+    if ($method eq 'Cookie/set' && $arg->{outofthisworld}) {
       return 0;
     }
 

--- a/t/lib/Bakesale/Schema/Result/Biscuit.pm
+++ b/t/lib/Bakesale/Schema/Result/Biscuit.pm
@@ -22,7 +22,7 @@ __PACKAGE__->ix_add_properties(
 
 __PACKAGE__->set_primary_key('id');
 
-sub ix_type_key { 'biscuits' }
+sub ix_type_key { 'Biscuit' }
 
 sub ix_account_type { 'generic' }
 

--- a/t/lib/Bakesale/Schema/Result/Cake.pm
+++ b/t/lib/Bakesale/Schema/Result/Cake.pm
@@ -35,7 +35,7 @@ __PACKAGE__->has_many(
   { 'foreign.cakeId' => 'self.id' },
 );
 
-sub ix_type_key { 'cakes' }
+sub ix_type_key { 'Cake' }
 
 sub ix_account_type { 'generic' }
 
@@ -54,7 +54,7 @@ sub ix_get_check ($self, $ctx, $arg) {
 sub ix_state_string ($self, $state) {
   return join q{-},
     $state->state_for($self->ix_type_key),
-    $state->state_for('cakeRecipes');
+    $state->state_for('CakeRecipe');
 }
 
 sub ix_compare_state ($self, $since, $state) {
@@ -64,11 +64,11 @@ sub ix_compare_state ($self, $since, $state) {
     unless ($cake_since//'')    =~ /\A[0-9]+\z/
         && ($recipe_since//'')  =~ /\A[0-9]+\z/;
 
-  my $cake_high   = $state->highest_modseq_for('cakes');
-  my $recipe_high = $state->highest_modseq_for('cakeRecipes');
+  my $cake_high   = $state->highest_modseq_for('Cake');
+  my $recipe_high = $state->highest_modseq_for('CakeRecipe');
 
-  my $cake_low    = $state->lowest_modseq_for('cakes');
-  my $recipe_low  = $state->lowest_modseq_for('cakeRecipes');
+  my $cake_low    = $state->lowest_modseq_for('Cake');
+  my $recipe_low  = $state->lowest_modseq_for('CakeRecipe');
 
   if ($cake_high < $cake_since || $recipe_high < $recipe_since) {
     return Ix::StateComparison->bogus;
@@ -154,7 +154,7 @@ sub ix_update_single_state_conds ($self, $example_row) {
 sub ix_created ($self, $ctx, $row) {
   return unless $row->type eq 'wedding';
 
-  my $handler = $ctx->processor->handler_for('setCakeToppers');
+  my $handler = $ctx->processor->handler_for('CakeTopper/set');
 
   my @results = $ctx->processor->$handler($ctx, {
     create => { $row->id => { cakeId => $row->id } },
@@ -180,7 +180,7 @@ sub ix_postprocess_set ($self, $ctx, $results) {
     )->get_column('id')->all;
     next unless @tids;
 
-    my $handler = $ctx->processor->handler_for('getCakeToppers');
+    my $handler = $ctx->processor->handler_for('CakeTopper/get');
     push @$results, $ctx->processor->$handler($ctx, { ids => [ @tids ] });
   }
 

--- a/t/lib/Bakesale/Schema/Result/Cake.pm
+++ b/t/lib/Bakesale/Schema/Result/Cake.pm
@@ -234,15 +234,6 @@ sub ix_get_list_filter_map {
   };
 }
 
-sub ix_get_list_fetchable_map {
-  return {
-    fetchRecipes => {
-      field      => 'recipeId',
-      result_set => 'CakeRecipe',
-    },
-  };
-}
-
 sub ix_get_list_joins {
   return $ENV{RECIPEID_NOT_REQUIRED}
     ? ('topper')

--- a/t/lib/Bakesale/Schema/Result/Cake.pm
+++ b/t/lib/Bakesale/Schema/Result/Cake.pm
@@ -19,7 +19,7 @@ __PACKAGE__->ix_add_properties(
   baked_at    => { data_type => 'timestamptz', client_may_init => 0, client_may_update => 0 },
   recipeId    => {
     data_type    => 'idstr',
-    xref_to      => 'cakeRecipes',
+    xref_to      => 'CakeRecipe',
   },
 );
 

--- a/t/lib/Bakesale/Schema/Result/Cake.pm
+++ b/t/lib/Bakesale/Schema/Result/Cake.pm
@@ -87,6 +87,11 @@ sub ix_compare_state ($self, $since, $state) {
 
 sub ix_update_state_string_field { 'jointModSeq' }
 
+sub ix_item_created_since ($self, $item, $since) {
+  my ($cake_since,  $recipe_since)  = split /-/, $since, 2;
+  return $item->{modSeqCreated} > $cake_since;
+}
+
 sub ix_highest_state ($self, $since, $rows) {
   my ($cake_since,  $recipe_since)  = split /-/, $since, 2;
 

--- a/t/lib/Bakesale/Schema/Result/CakeRecipe.pm
+++ b/t/lib/Bakesale/Schema/Result/CakeRecipe.pm
@@ -20,7 +20,7 @@ __PACKAGE__->ix_add_properties(
 
 __PACKAGE__->set_primary_key('id');
 
-sub ix_type_key { 'cakeRecipes' }
+sub ix_type_key { 'CakeRecipe' }
 
 sub ix_account_type { 'generic' }
 

--- a/t/lib/Bakesale/Schema/Result/CakeTopper.pm
+++ b/t/lib/Bakesale/Schema/Result/CakeTopper.pm
@@ -17,7 +17,7 @@ __PACKAGE__->ix_add_properties(
   type   => { data_type => 'string',     },
   cakeId => {
     data_type    => 'idstr',
-    xref_to      => 'cakes'
+    xref_to      => 'Cake'
   },
 );
 

--- a/t/lib/Bakesale/Schema/Result/CakeTopper.pm
+++ b/t/lib/Bakesale/Schema/Result/CakeTopper.pm
@@ -23,7 +23,7 @@ __PACKAGE__->ix_add_properties(
 
 __PACKAGE__->set_primary_key('id');
 
-sub ix_type_key { 'cakeToppers' }
+sub ix_type_key { 'CakeTopper' }
 
 sub ix_account_type { 'generic' }
 

--- a/t/lib/Bakesale/Schema/Result/Cookie.pm
+++ b/t/lib/Bakesale/Schema/Result/Cookie.pm
@@ -28,7 +28,7 @@ __PACKAGE__->ix_add_properties(
 
 __PACKAGE__->set_primary_key('id');
 
-sub ix_type_key { 'cookies' }
+sub ix_type_key { 'Cookie' }
 
 sub ix_account_type { 'generic' }
 

--- a/t/lib/Bakesale/Schema/Result/Cookie.pm
+++ b/t/lib/Bakesale/Schema/Result/Cookie.pm
@@ -142,8 +142,6 @@ sub ix_get_list_filter_map {
   };
 }
 
-sub ix_get_list_fetchable_map { { } }
-
 sub ix_get_list_joins { () }
 
 sub ix_get_list_check ($self, $ctx, $arg, $search) {

--- a/t/lib/Bakesale/Schema/Result/User.pm
+++ b/t/lib/Bakesale/Schema/Result/User.pm
@@ -181,8 +181,6 @@ sub ix_get_list_filter_map {
   };
 }
 
-sub ix_get_list_fetchable_map { {} }
-
 sub ix_get_list_joins { () }
 
 sub ix_get_list_check { }

--- a/t/lib/Bakesale/Schema/Result/User.pm
+++ b/t/lib/Bakesale/Schema/Result/User.pm
@@ -32,7 +32,7 @@ sub ix_extra_deployment_statements {
 
 sub ix_account_type { 'generic' }
 
-sub ix_type_key { 'users' }
+sub ix_type_key { 'User' }
 
 sub ix_is_account_base { 1 }
 

--- a/t/processor/basic.t
+++ b/t/processor/basic.t
@@ -103,7 +103,7 @@ my $ctx = $Bakesale->get_context({
         '#ids' => {
           resultOf => 'a',
           name => 'Cookie/changes',
-          path => '/changed'
+          path => '/created'
         },
       },
       'b',
@@ -250,8 +250,9 @@ my @created_ids;
           oldState => 8,
           newState => 9,
           hasMoreUpdates => bool(0),
-          changed  => bag($account{cookies}{1}, @created_ids),
-          removed  => bag($account{cookies}{4}),
+          created   => bag(@created_ids),
+          updated   => [ $account{cookies}{1} ],
+          destroyed => bag($account{cookies}{4}),
         },
         'a',
       ],
@@ -308,10 +309,20 @@ subtest "invalid sinceState" => sub {
         '#ids' => {
           resultOf => 'a',
           name => 'Cookie/changes',
-          path => '/changed',
+          path => '/created',
         },
       },
       'b',
+    ],
+    [
+      'Cookie/get' => {
+        '#ids' => {
+          resultOf => 'a',
+          name => 'Cookie/changes',
+          path => '/updated',
+        },
+      },
+      'c',
     ]
   ]);
 
@@ -324,17 +335,25 @@ subtest "invalid sinceState" => sub {
           oldState => 8,
           newState => 9,
           hasMoreUpdates => bool(0),
-          changed  => bag($account{cookies}{1}, @created_ids),
-          removed  => bag($account{cookies}{4}),
+          created   => bag(@created_ids),
+          updated   => [ $account{cookies}{1} ],
+          destroyed => bag($account{cookies}{4}),
         },
         'a',
       ],
       [
         'Cookie/get' => {
           $get_res->[0][1]->%*,
-          list => bag( $get_res->[0][1]{list}->@* ),
+          list => bag( $get_res->[0][1]{list}->@[1..2] ),
         },
         'b',
+      ],
+      [
+        'Cookie/get' => {
+          $get_res->[0][1]->%*,
+          list => bag( $get_res->[0][1]{list}->[0] ),
+        },
+        'c',
       ]
     ],
     "updates can be got with backrefs",
@@ -472,7 +491,7 @@ subtest "invalid sinceState" => sub {
         '#ids' => {
           resultOf => 'a',
           name => 'Cookie/changes',
-          path => '/changed'
+          path => '/created'
         },
       }, 'b',
     ]
@@ -551,7 +570,7 @@ subtest "invalid sinceState" => sub {
         '#ids' => {
           resultOf => 'a',
           name => 'Cookie/changes',
-          path => '/changed',
+          path => '/updated',
         },
       },
       'b',

--- a/t/processor/basic.t
+++ b/t/processor/basic.t
@@ -567,7 +567,7 @@ subtest "invalid sinceState" => sub {
         'b',
       ],
     ],
-    "a getFoos call backed by the database",
+    "a Foo/get call backed by the database",
   ) or diag explain($res);
 
   ok($res->[1][1]{list}[0]{baked_at}->$_isa('DateTime'), 'got a dt object');

--- a/t/processor/basic.t
+++ b/t/processor/basic.t
@@ -6,6 +6,7 @@ use lib 't/lib';
 
 use Bakesale;
 use Bakesale::Schema;
+use Capture::Tiny qw(capture_stderr);
 use Test::Deep;
 use Test::More;
 use Safe::Isa;
@@ -607,20 +608,22 @@ subtest "invalid sinceState" => sub {
   # not reused
   $ctx = $ctx->with_account('generic' => undef);
 
-  print STDERR "Ignore the next exception report for now..\n";
-  my $error = try {
-    $ctx->process_request([
-      [
-        'Cake/set' => { create => [] },
-      ],
-    ]);
+  capture_stderr(sub {
+    print STDERR "Ignore the next exception report for now..\n";
+    my $error = try {
+      $ctx->process_request([
+        [
+          'Cake/set' => { create => [] },
+        ],
+      ]);
 
-    return;
-  } catch {
-    return $_;
-  };
+      return;
+    } catch {
+      return $_;
+    };
 
-  ok($error, 'process_request died');
+    ok($error, 'process_request died');
+  });
 
   # Make another call with that ctx, should succeed
   my $cake_res = $ctx->process_request([

--- a/t/processor/basic.t
+++ b/t/processor/basic.t
@@ -16,6 +16,7 @@ my $no_updates = any({}, undef);
 
 my $Bakesale = Bakesale->new;
 \my %account = Bakesale::Test->load_trivial_account($Bakesale->schema_connection);
+my $accountId = $account{accounts}{rjbs};
 
 my $ctx = $Bakesale->get_context({
   userId => $account{users}{rjbs},
@@ -115,6 +116,7 @@ my $ctx = $Bakesale->get_context({
       [ 'Cookie/changes' => ignore(), 'a' ],
       [
         'Cookie/get' => {
+          accountId => $accountId,
           notFound => undef,
           state => 8,
           list  => [
@@ -170,6 +172,7 @@ my @created_ids;
     [
       [
         'Cookie/set' => superhashof({
+          accountId => ignore(),
           oldState => 8,
           newState => 9,
 
@@ -204,7 +207,7 @@ my @created_ids;
   @created_ids = map {; $_->{id} } values %{ $res->[0][1]{created} };
 
   my @rows = $ctx->schema->resultset('Cookie')->search(
-    { accountId => $account{accounts}{rjbs} },
+    { accountId => $accountId },
     {
       order_by => 'baked_at',
       result_class => 'DBIx::Class::ResultClass::HashRefInflator',
@@ -226,7 +229,7 @@ my @created_ids;
   ) or diag explain(\@rows);
 
   my $state = $ctx->schema->resultset('State')->search({
-    accountId => $account{accounts}{rjbs},
+    accountId => $accountId,
     type => 'Cookie',
   })->first;
 
@@ -243,6 +246,7 @@ my @created_ids;
     [
       [
         'Cookie/changes' => {
+          accountId => ignore(),
           oldState => 8,
           newState => 9,
           hasMoreUpdates => bool(0),
@@ -316,6 +320,7 @@ subtest "invalid sinceState" => sub {
     [
       [
         'Cookie/changes' => {
+          accountId => ignore(),
           oldState => 8,
           newState => 9,
           hasMoreUpdates => bool(0),
@@ -397,7 +402,7 @@ subtest "invalid sinceState" => sub {
   ) or diag explain($res);
 
   my $state = $ctx->schema->resultset('State')->search({
-    accountId => $account{accounts}{rjbs},
+    accountId => $accountId,
     type => 'Cookie',
   })->first;
 
@@ -479,6 +484,7 @@ subtest "invalid sinceState" => sub {
       [ 'Cookie/changes' => ignore(), 'a' ],
       [
         'Cookie/get' => {
+          accountId => ignore(),
           notFound => undef,
           state => 10,
           list  => set(
@@ -558,6 +564,7 @@ subtest "invalid sinceState" => sub {
       [ 'Cookie/changes' => ignore(), 'a' ],
       [
         'Cookie/get' => {
+          accountId => ignore(),
           notFound => undef,
           state => 11,
           list  => [
@@ -582,7 +589,7 @@ subtest "invalid sinceState" => sub {
   my $res = $ctx->process_request([
     [
       'Cookie/set' => {
-        accountId => $account,
+        accountId => $accountId,
         ifInState => 11,
         create    => {
           yellow => { type => 'shortbread', },

--- a/xt/states.t
+++ b/xt/states.t
@@ -85,7 +85,7 @@ END {
 # Get some initial state
 my $res = $jmap_tester->request([
   [
-    setCookies => {
+    'Cookie/set' => {
       create => { raw => { type => 'dough', baked_at => undef } },
     },
   ],
@@ -111,7 +111,7 @@ my $state = $res->single_sentence->arguments->{newState};
 ok(defined($state), 'got new state');
 
 # Start 3 processes, 2 with the same accountId. Of the latter 2, have one
-# do a setCakes then setCookies, and the other the reverse. This makes
+# do a Cake/set then Cookie/set, and the other the reverse. This makes
 # sure we don't deadlock by holding onto a lock for too long. All calls
 # should succeed and the state should be bumped twice in the one account.
 
@@ -149,12 +149,12 @@ $signaled = 0;
 my $child1 = with_child {
   my $res = $jmap_tester->request([
     [
-      setCookies => {
+      'Cookie/set' => {
         create => { raw => { type => 'first', baked_at => undef } },
       },
     ],
     [
-      setCakes   => {
+      'Cake/set'   => {
         create => { raw => { type => 'first', layer_count => 4, recipeId => $account{recipes}{1} } },
       },
     ],
@@ -172,11 +172,11 @@ my $child1 = with_child {
 my $child2 = with_child {
   my $res = $jmap_tester->request([
     [
-      setCakes   => {
+      'Cake/set'   => {
         create => { raw => { type => 'second', layer_count => 4, recipeId => $account{recipes}{1} } },
       },
     ], [
-      setCookies => {
+      'Cookie/set' => {
         create => { raw => { type => 'second', baked_at => undef } },
       },
     ],
@@ -194,12 +194,12 @@ my $child2 = with_child {
 my $child3 = with_child {
   my $res = $jmap_tester2->request([
     [
-      setCookies => {
+      'Cookie/set' => {
         create => { raw => { type => 'other', baked_at => undef } },
       },
     ],
     [
-      setCakes   => {
+      'Cake/set'   => {
         create => { raw => { type => 'other', layer_count => 4, recipeId => $account{recipes}{1} } },
       },
     ],
@@ -243,7 +243,7 @@ is($signaled, 3, 'children report they are complete');
 
 # This should give us two cookies, state increased by 1
 $res = $jmap_tester->request([
-  [ getCookieUpdates => {
+  [ 'Cookie/changes' => {
     sinceState   => $state,
   } ],
 ]);
@@ -257,7 +257,7 @@ is (@changed, 2, 'two cookies created')
 
 # This should give us one cookie, state increased by 1
 $res = $jmap_tester->request([
-  [ getCookieUpdates => {
+  [ 'Cookie/changes' => {
     sinceState  => $state + 1,
   } ],
 ]);

--- a/xt/states.t
+++ b/xt/states.t
@@ -161,10 +161,10 @@ my $child1 = with_child {
   ]);
 
   if (! $res->sentence(0)->arguments->{created}) {
-    die "Bad response: " . Dumper($res->as_stripped_struct);
+    die "Bad response: " . Dumper($res->as_stripped_triples);
   }
   if (! $res->sentence(1)->arguments->{created}) {
-    die "Bad response: " . Dumper($res->as_stripped_struct);
+    die "Bad response: " . Dumper($res->as_stripped_triples);
   }
 };
 
@@ -183,10 +183,10 @@ my $child2 = with_child {
   ]);
 
   if (! $res->sentence(0)->arguments->{created}) {
-    die "Bad response: " . Dumper($res->as_stripped_struct);
+    die "Bad response: " . Dumper($res->as_stripped_triples);
   }
   if (! $res->sentence(1)->arguments->{created}) {
-    die "Bad response: " . Dumper($res->as_stripped_struct);
+    die "Bad response: " . Dumper($res->as_stripped_triples);
   }
 };
 
@@ -206,10 +206,10 @@ my $child3 = with_child {
   ]);
 
   if (! $res->sentence(0)->arguments->{created}) {
-    die "Bad response: " . Dumper($res->as_stripped_struct);
+    die "Bad response: " . Dumper($res->as_stripped_triples);
   }
   if (! $res->sentence(1)->arguments->{created}) {
-    die "Bad response: " . Dumper($res->as_stripped_struct);
+    die "Bad response: " . Dumper($res->as_stripped_triples);
   }
 };
 
@@ -253,7 +253,7 @@ is($new_state, $state + 2, "state bumped twice");
 
 my @changed = $res->sentence(0)->arguments->{changed}->@*;
 is (@changed, 2, 'two cookies created')
-  or diag explain $res->as_stripped_struct;
+  or diag explain $res->as_stripped_triples;
 
 # This should give us one cookie, state increased by 1
 $res = $jmap_tester->request([
@@ -267,6 +267,8 @@ is($new_state, $state + 2, "state bumped twice");
 
 @changed = $res->sentence(0)->arguments->{changed}->@*;
 is (@changed, 1, 'one cookie created')
-  or diag explain $res->as_stripped_struct;
+  or diag explain $res->as_stripped_triples;
+
+$app->_shutdown;
 
 done_testing;

--- a/xt/states2.t
+++ b/xt/states2.t
@@ -1,0 +1,232 @@
+use 5.20.0;
+use warnings;
+use utf8;
+use experimental qw(lexical_subs signatures postderef refaliasing);
+
+use lib 't/lib';
+
+use Bakesale;
+
+BEGIN {
+  no warnings qw(redefine);
+
+  # So we don't hit the for update lock timeout of 2s
+  *Bakesale::database_defaults = sub {
+    return (
+      "SET LOCK_TIMEOUT TO '50s'",
+    );
+  }
+}
+
+use Bakesale::App;
+use Bakesale::Schema;
+use JSON;
+use Test::Deep;
+use Test::Deep::JType;
+use Test::More;
+use Unicode::Normalize;
+use Data::Dumper;
+use Process::Status;
+use Path::Tiny;
+
+my ($app, $jmap_tester) = Bakesale::Test->new_test_app_and_tester;
+\my %account = Bakesale::Test->load_trivial_account($app->processor->schema_connection);
+
+$jmap_tester->_set_cookie('bakesaleUserId', $account{users}{rjbs});
+
+# Clear our states table
+$app->processor->schema_connection->storage->dbh->do("DELETE FROM states");
+$app->processor->schema_connection->storage->dbh->do("DELETE FROM cookies");
+
+my %children;
+my $parent_pid = $$;
+
+# Each child needs to send us a different signal or we may miss a
+# signal if more than one child sends it to us at the same time
+my @SIGNALS = qw(USR1 USR2 TERM HUP);
+
+my $signaled = 0;
+
+for my $sig (@SIGNALS) {
+  $SIG{$sig} = sub { $signaled++; };
+}
+
+sub with_child ($code) :prototype(&) {
+  my $sig = shift @SIGNALS;
+
+  my $res = fork;
+  if ($res) {
+    $children{$res} = 1;
+
+    return $res;
+  }
+
+  # Let parent know we started
+  kill $sig => $parent_pid;
+
+  # unblock_child() will take us passed this
+  sleep 30;
+
+  $code->();
+
+  # Signal our parent we're done
+  kill $sig => $parent_pid;
+
+  exit;
+}
+
+sub unblock_child ($child) {
+  kill 'USR1' => $child;
+}
+
+sub end_child ($child) {
+  kill 'KILL' => $child;
+}
+
+END {
+  for my $k (keys %children) {
+    waitpid($k, 0);
+  }
+
+  # Clean up $? or our test reports a failure
+  exit;
+}
+
+# Start 2 processes. Have them both try to create a cookie which will
+# set the cookie state. One should succeed, one should fail, and the
+# failed ones should not leave cookies behind
+
+my $lock = with_child {
+  my $schema = $app->processor->schema_connection;
+
+  $schema->txn_do(sub {
+    $schema->storage->dbh->do("LOCK TABLE states IN ACCESS EXCLUSIVE MODE");
+
+    # Let parent know we have the lock
+    kill 'USR1' => $parent_pid;
+
+    # main proc will take us passed this
+    sleep 60;
+  });
+};
+
+while (!$signaled) {
+  note("waiting for locker to start up\n");
+  sleep 1;
+}
+
+$signaled = 0;
+
+unblock_child($lock);
+
+while (!$signaled) {
+  note("waiting for locker to lock\n");
+  sleep 1;
+}
+
+$signaled = 0;
+
+my $c1f = Path::Tiny->tempfile;
+
+# Our first set cookies
+my $child1 = with_child {
+  my $res = $jmap_tester->request([
+    [
+      setCookies => {
+        create => { raw => { type => 'first', baked_at => undef } },
+      },
+    ],
+  ]);
+
+  $c1f->spew($res->http_response->decoded_content);
+};
+
+my $c2f = Path::Tiny->tempfile;
+
+# Our second set cookies
+my $child2 = with_child {
+  my $res = $jmap_tester->request([
+    [
+      setCookies => {
+        create => { raw => { type => 'second', baked_at => undef } },
+      },
+    ],
+  ]);
+
+  $c2f->spew($res->http_response->decoded_content);
+};
+
+while ($signaled != 2) {
+  note("waiting for our children to start up");
+  sleep 1;
+}
+
+for my $child ($child1, $child2) {
+  unblock_child($child);
+}
+
+note 'children are blocked on our lock, waiting a second and releasing';
+
+sleep 1;
+
+$signaled = 0;
+
+end_child($lock);
+
+# These have been freed up when we released the lock and should
+# do their thing then exit
+for my $pid ($child1, $child2) {
+  ok(waitpid($pid, 0), "child exited");
+}
+
+# And they should have signaled us before exiting
+is($signaled, 2, 'both children completed');
+
+# This should give us one cookie, state increased by 1
+my $res = $jmap_tester->request([
+  [ getCookies => {} ],
+]);
+
+my $fail = 0;
+
+is(
+  $res->single_sentence('cookies')->arguments->{list}->@*,
+  1,
+  'only created one cookie'
+) or $fail++;
+
+is(
+  $res->single_sentence('cookies')->arguments->{state},
+  1,
+  'state only incremented once'
+) or $fail++;
+
+diag explain $res->as_stripped_triples if $fail;
+
+my $res1 = $c1f->slurp;
+my $res2 = $c2f->slurp;
+
+ok($res1, 'got child 1 output');
+ok($res2, 'got child2 output');
+
+$res1 = decode_json($res1);
+$res2 = decode_json($res2);
+
+my $res1type = $res1->{methodResponses}[0][0];
+my $res2type = $res2->{methodResponses}[0][0];
+
+jcmp_deeply(
+  [ $res1type, $res2type ],
+  set('cookiesSet', 'error'),
+  'got one success, one fail'
+);
+
+my $err = $res1type eq 'error'
+            ? $res1->{methodResponses}[0][1]
+            : $res2->{methodResponses}[0][1];
+
+is($err->{type}, 'tryAgain', 'got correct error');
+
+$app->_shutdown;
+
+done_testing;

--- a/xt/states2.t
+++ b/xt/states2.t
@@ -132,7 +132,7 @@ my $c1f = Path::Tiny->tempfile;
 my $child1 = with_child {
   my $res = $jmap_tester->request([
     [
-      setCookies => {
+      'Cookie/set' => {
         create => { raw => { type => 'first', baked_at => undef } },
       },
     ],
@@ -147,7 +147,7 @@ my $c2f = Path::Tiny->tempfile;
 my $child2 = with_child {
   my $res = $jmap_tester->request([
     [
-      setCookies => {
+      'Cookie/set' => {
         create => { raw => { type => 'second', baked_at => undef } },
       },
     ],
@@ -184,19 +184,19 @@ is($signaled, 2, 'both children completed');
 
 # This should give us one cookie, state increased by 1
 my $res = $jmap_tester->request([
-  [ getCookies => {} ],
+  [ 'Cookie/get' => {} ],
 ]);
 
 my $fail = 0;
 
 is(
-  $res->single_sentence('cookies')->arguments->{list}->@*,
+  $res->single_sentence('Cookie/get')->arguments->{list}->@*,
   1,
   'only created one cookie'
 ) or $fail++;
 
 is(
-  $res->single_sentence('cookies')->arguments->{state},
+  $res->single_sentence('Cookie/get')->arguments->{state},
   1,
   'state only incremented once'
 ) or $fail++;
@@ -217,7 +217,7 @@ my $res2type = $res2->{methodResponses}[0][0];
 
 jcmp_deeply(
   [ $res1type, $res2type ],
-  set('cookiesSet', 'error'),
+  set('Cookie/set', 'error'),
   'got one success, one fail'
 );
 


### PR DESCRIPTION
This does a couple of things:

- rename all methods to new-style JMAP (Foo/get rather than getFoos)
- converts fetchFoos to explicit backrefs in tests
- removes all trace of fetchFoos from lib/ code
- assumes that ix_type_key a capitalized, singular noun (the "Foo" of "Foo/get"); and also removes ix_type_key_singular
