### PR TITLE
Minor changes per spec

### DIFF
--- a/lib/Ix/DBIC/ResultSet.pm
+++ b/lib/Ix/DBIC/ResultSet.pm
@@ -254,7 +254,7 @@ sub ix_get_updates ($self, $ctx, $arg = {}) {
 
     my @return = $ctx->result($res_type => {
       oldState => "$since",
-      newState => ($hasMoreUpdates
+      newState => "" . ($hasMoreUpdates
                 ? $rclass->ix_highest_state($since, \@rows)
                 : $rclass->ix_state_string($ctx->state)),
       hasMoreUpdates => $hasMoreUpdates

--- a/lib/Ix/DBIC/ResultSet.pm
+++ b/lib/Ix/DBIC/ResultSet.pm
@@ -220,14 +220,10 @@ sub ix_get_updates ($self, $ctx, $arg = {}) {
       my @trimmed_rows = grep { $_->{$state_string_field} ne $maxState } @rows;
 
       if (@trimmed_rows == 0) {
-        # ... well, it turns out that the entire batch was in one state.  We
-        # can't possibly provide a consistent update within the bounds that the
-        # user requested.  When this happens, we're permitted to provide more
-        # records than requested, so let's just fetch one state worth of
-        # records. -- rjbs, 2016-02-22
-        @rows = $search->search(
-          $rclass->ix_update_single_state_conds($rows[0])
-        )->all;
+        # We used to just return everything here, but a JMAP API spec change
+        # (9ba6b5f75) means that we now must return a cannotCalculateChanges.
+        # -- michael, 2019-01-30
+        return $ctx->error(cannotCalculateChanges => {});
       } else {
         @rows = @trimmed_rows;
       }

--- a/t/updates.t
+++ b/t/updates.t
@@ -135,6 +135,15 @@ subtest "simple state comparisons" => sub {
     my ($type, $arg) = $res->single_sentence->as_triple->@*;
     is($type, 'Cookie/changes', 'cookie changes!!');
 
+    jcmp_deeply(
+      $arg,
+      superhashof({
+        oldState => jstr(),
+        newState => jstr(),
+      }),
+      'state strings are, in fact, strings'
+    );
+
     is($arg->{oldState}, 2, "old state: 2");
     is($arg->{newState}, 3, "new state: 3");
     ok($arg->{hasMoreUpdates},   "more updates to get");


### PR DESCRIPTION
$rclass->ix_state_string returned a string, but
$rclass->ix_highest_state did not always do so, so in Foo/changes,
newState could be a number.