### PR TITLE
JMAP proc: be opaque in logs for unknown methods

### DIFF
--- a/t/access_log.t
+++ b/t/access_log.t
@@ -72,6 +72,9 @@ capture_stderr(sub {
         }
       }, "my id"
     ],
+    [
+      q{`cat /etc/passwd`} => {}, 'x',
+    ]
   ]);
 });
 
@@ -85,6 +88,11 @@ cmp_deeply(
           yum => { guid => ignore(), type => 'internalError' },
         },
       }), 'my id'
+    ],
+    [
+      error => {
+        type => 'unknownMethod',
+      }, 'x'
     ]
   ],
   "errors bubble up"
@@ -114,6 +122,9 @@ for my $line (@lines) {
         call_info => [
           [
             'Cake/set' => { elapsed_seconds => $elapsed_re },
+          ],
+          [
+            'IX_INTERNAL/unknownMethod' => { elapsed_seconds => $elapsed_re },
           ],
         ],
         exception_guids => [ re('[A-Z0-9-]+'), re('[A-Z0-9-]+') ],


### PR DESCRIPTION
Right now, if you try to call a method that doesn't exist, we'll happily
pass that through to record_call_info. This has led to some weird things
in our stats processor, where we log status for every API call by type.

I'm not crazy about the way this is done, but it seems right to do it in
Ix, and it's nice to have _some_ way of logging that an unknown method
was called. I suppose the other thing to do would just be not to record
it if it was an unknown method, but that seems less good.