### PR TITLE
Rename methods to match JMAP names

### DIFF
--- a/lib/Ix/DBIC/Result.pm
+++ b/lib/Ix/DBIC/Result.pm
@@ -18,7 +18,7 @@ sub ix_account_type { Carp::confess("ix_account_type not implemented") }
 # Checked for in ix_finalize
 # sub ix_type_key { }
 
-sub ix_get_list_enabled {}
+sub ix_query_enabled {}
 sub ix_extra_get_args { }
 
 # Must be specified if the rclass represents a new 'account'
@@ -204,40 +204,40 @@ sub ix_finalize ($class) {
 
   my $prop_info = $class->ix_property_info;
 
-  if ($class->ix_get_list_enabled) {
+  if ($class->ix_query_enabled) {
     my @missing;
 
     for my $method (qw(
-      ix_get_list_check
-      ix_get_list_updates_check
-      ix_get_list_filter_map
-      ix_get_list_sort_map
-      ix_get_list_joins
+      ix_query_check
+      ix_query_changes_check
+      ix_query_filter_map
+      ix_query_sort_map
+      ix_query_joins
     )) {
       push @missing, $method unless $class->can($method);
     }
 
     if (@missing) {
       Carp::confess(
-          "$class - ix_get_list_enabled is true but these required methods are missing: "
+          "$class - ix_query_enabled is true but these required methods are missing: "
         . join(', ', @missing)
       );
     }
 
     # Ensure filters are diffable. If they aren't we'll crash in
-    # ix_get_list_updates when trying to figure out if something has changed.
+    # ix_query_changes when trying to figure out if something has changed.
     # For now, we require that either:
     #
     #  - The filter is a property of the class (it's in by ix_property_info)
     #  - The filter specifies its own custom differ
     #  - The filter contains a relationship ('this.that') and the relationship
-    #    is listed as joinable in ix_get_list_joins. (Note that we do
+    #    is listed as joinable in ix_query_joins. (Note that we do
     #    not verify the columns on the related tables... yet...)
     my @broken;
 
-    my $fmap = $class->ix_get_list_filter_map;
+    my $fmap = $class->ix_query_filter_map;
 
-    my %joins = map { $_ => 1 } $class->ix_get_list_joins;
+    my %joins = map { $_ => 1 } $class->ix_query_joins;
 
     for my $k (keys %$fmap) {
       my $rel_ok;
@@ -259,7 +259,7 @@ sub ix_finalize ($class) {
 
     if (@broken) {
       Carp::confess(
-          "$class - ix_get_list_filter_map has filters that don't match columns or have custom differs: "
+          "$class - ix_query_filter_map has filters that don't match columns or have custom differs: "
         . join(', ', @broken)
       );
     }
@@ -280,7 +280,7 @@ sub ix_get_check              { } # ($self, $ctx, \%arg)
 sub ix_create_check           { } # ($self, $ctx, \%rec)
 sub ix_update_check           { } # ($self, $ctx, $row, \%rec)
 sub ix_destroy_check          { } # ($self, $ctx, $row)
-sub ix_get_updates_check      { } # ($self, $ctx, \%arg)
+sub ix_changes_check          { } # ($self, $ctx, \%arg)
 
 sub ix_create_error  { return; } # ($self, $ctx, \%error)
 sub ix_update_error  { return; } # ($self, $ctx, \%error)

--- a/lib/Ix/Processor/JMAP.pm
+++ b/lib/Ix/Processor/JMAP.pm
@@ -62,19 +62,19 @@ has _dbic_handlers => (
       };
 
       $handler{"$key/changes"} = sub ($self, $ctx, $arg = {}) {
-        $ctx->schema->resultset($moniker)->ix_get_updates($ctx, $arg);
+        $ctx->schema->resultset($moniker)->ix_changes($ctx, $arg);
       };
 
       $handler{"$key/set"} = sub ($self, $ctx, $arg) {
         $ctx->schema->resultset($moniker)->ix_set($ctx, $arg);
       };
 
-      if ($rclass->ix_get_list_enabled) {
+      if ($rclass->ix_query_enabled) {
         $handler{"$key/query"} = sub ($self, $ctx, $arg) {
-          $ctx->schema->resultset($moniker)->ix_get_list($ctx, $arg);
+          $ctx->schema->resultset($moniker)->ix_query($ctx, $arg);
         };
         $handler{"$key/queryChanges"} = sub ($self, $ctx, $arg) {
-          $ctx->schema->resultset($moniker)->ix_get_list_updates($ctx, $arg);
+          $ctx->schema->resultset($moniker)->ix_query_changes($ctx, $arg);
         };
       }
     }

--- a/t/changes.t
+++ b/t/changes.t
@@ -521,7 +521,7 @@ subtest "updated null and updated Object" => sub {
   }
 };
 
-subtest "Foo/changes - ix_get_updates_check" => sub {
+subtest "Foo/changes - ix_changes_check" => sub {
   {
     my $res = $jmap_tester->request([
       [

--- a/t/lib/Bakesale/Schema/Result/Cake.pm
+++ b/t/lib/Bakesale/Schema/Result/Cake.pm
@@ -192,7 +192,7 @@ sub ix_postprocess_set ($self, $ctx, $results) {
   return;
 }
 
-sub ix_get_list_sort_map {
+sub ix_query_sort_map {
   return {
     created     => { },
     id          => { },
@@ -209,7 +209,7 @@ sub ix_get_list_sort_map {
   };
 }
 
-sub ix_get_list_filter_map {
+sub ix_query_filter_map {
   return {
     recipeId    => {
       $ENV{RECIPEID_NOT_REQUIRED} ? () : (required => 1)
@@ -239,13 +239,13 @@ sub ix_get_list_filter_map {
   };
 }
 
-sub ix_get_list_joins {
+sub ix_query_joins {
   return $ENV{RECIPEID_NOT_REQUIRED}
     ? ('topper')
     : ('recipe', 'topper');
 }
 
-sub ix_get_list_check ($self, $ctx, $arg, $search) {
+sub ix_query_check ($self, $ctx, $arg, $search) {
   if (
        exists $arg->{filter}
     && exists $arg->{filter}{recipeId}
@@ -265,7 +265,7 @@ sub ix_get_list_check ($self, $ctx, $arg, $search) {
   return;
 }
 
-sub ix_get_list_updates_check ($self, $ctx, $arg, $search) {
+sub ix_query_changes_check ($self, $ctx, $arg, $search) {
   if (
        exists $arg->{filter}
     && exists $arg->{filter}{recipeId}
@@ -285,7 +285,7 @@ sub ix_get_list_updates_check ($self, $ctx, $arg, $search) {
   return;
 }
 
-sub ix_get_list_enabled { 1 }
+sub ix_query_enabled { 1 }
 
 sub ix_published_method_map {
   return {

--- a/t/lib/Bakesale/Schema/Result/Cookie.pm
+++ b/t/lib/Bakesale/Schema/Result/Cookie.pm
@@ -116,7 +116,7 @@ sub ix_destroy_check ($self, $ctx, $row) {
   return;
 }
 
-sub ix_get_list_sort_map {
+sub ix_query_sort_map {
   return {
     type        => { },
     baked_at    => { },
@@ -125,7 +125,7 @@ sub ix_get_list_sort_map {
   };
 }
 
-sub ix_get_list_filter_map {
+sub ix_query_filter_map {
   return {
     types => {
       cond_builder => sub ($types) {
@@ -142,9 +142,9 @@ sub ix_get_list_filter_map {
   };
 }
 
-sub ix_get_list_joins { () }
+sub ix_query_joins { () }
 
-sub ix_get_list_check ($self, $ctx, $arg, $search) {
+sub ix_query_check ($self, $ctx, $arg, $search) {
   if ($arg->{filter}{types}) {
     unless ((ref($arg->{filter}{types}) || '') eq 'ARRAY') {
       return $ctx->error(invalidArguments => {
@@ -156,10 +156,10 @@ sub ix_get_list_check ($self, $ctx, $arg, $search) {
   return;
 }
 
-sub ix_get_list_updates_check ($self, $ctx, $arg, $search) {
-  return $self->ix_get_list_check($ctx, $arg, $search);
+sub ix_query_changes_check ($self, $ctx, $arg, $search) {
+  return $self->ix_query_check($ctx, $arg, $search);
 }
 
-sub ix_get_list_enabled { 1 }
+sub ix_query_enabled { 1 }
 
 1;

--- a/t/lib/Bakesale/Schema/Result/User.pm
+++ b/t/lib/Bakesale/Schema/Result/User.pm
@@ -123,7 +123,7 @@ sub ix_create_check ($self, $ctx, $arg) {
   return;
 }
 
-sub ix_get_updates_check ($self, $ctx, $arg) {
+sub ix_changes_check ($self, $ctx, $arg) {
   # Not allowed to get more than 5 updates
   if ($arg->{limit} && $arg->{limit} > 5) {
     return $ctx->error(overLimit => {
@@ -165,7 +165,7 @@ sub ix_postprocess_create ($self, $ctx, $rows) {
   return;
 }
 
-sub ix_get_list_sort_map {
+sub ix_query_sort_map {
   return {
     username => { },
     status   => { },
@@ -173,7 +173,7 @@ sub ix_get_list_sort_map {
   };
 }
 
-sub ix_get_list_filter_map {
+sub ix_query_filter_map {
   return {
     username => { },
     status   => { },
@@ -181,11 +181,11 @@ sub ix_get_list_filter_map {
   };
 }
 
-sub ix_get_list_joins { () }
+sub ix_query_joins { () }
 
-sub ix_get_list_check { }
-sub ix_get_list_updates_check { }
+sub ix_query_check { }
+sub ix_query_changes_check { }
 
-sub ix_get_list_enabled { 1 }
+sub ix_query_enabled { 1 }
 
 1;

--- a/t/query.t
+++ b/t/query.t
@@ -70,7 +70,7 @@ ok($secret2_recipe_id, 'created a marble recipe');
       queryState => 0,
       total      => 0,
     }),
-    "ix_get_list works with no state rows"
+    "ix_query works with no state rows"
   );
 
   $res = $jmap_tester->request([
@@ -94,7 +94,7 @@ ok($secret2_recipe_id, 'created a marble recipe');
       newQueryState => 0,
       oldQueryState => 0,
     }),
-    "ix_get_list_update works with no state rows"
+    "ix_query_changes works with no state rows"
   );
 }
 
@@ -816,7 +816,7 @@ subtest "custom condition builder" => sub {
       type        => 'invalidArguments',
       description => "That recipe is too secret for you",
     },
-    "Cake/query ix_get_list_check hook works"
+    "Cake/query ix_query_check hook works"
   );
 
   jcmp_deeply(
@@ -825,7 +825,7 @@ subtest "custom condition builder" => sub {
       type        => 'invalidArguments',
       description => "That recipe is way too secret for you",
     },
-    "Cake/queryChanges ix_get_list_updates_check hook works"
+    "Cake/queryChanges ix_query_changes_check hook works"
   );
 }
 


### PR DESCRIPTION
I'm not sure why we decided not to do this when we did the big renaming.
This commit changes the method names (and their hooks) to better match
the JMAP verbs to which they correspond. That entails this set of
changes:

- `get_updates` is now `changes` (and related, so `ix_get_updates_check`
  is now `ix_changes_check`)

- `get_list_updates` is now `query_changes` (and so,
  `ix_query_changes_check`)

- `get_list` is now `query`. This was the biggest change, only because
  there are a bunch of auxiliary methods used for querying. These
  methods are now called ix_query_enabled, ix_query_check,
  ix_query_filter_map, ix_query_sort_map, and ix_query_joins.

This also changes the name of the tests so that they still make sense:
updates.t is now changes.t, and get_foo_list.t is now query.t.